### PR TITLE
rebrand + feat(plugins): oracle-v2→arra-oracle + WASM console

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oracle Studio
 
-React dashboard for [oracle-v2](https://github.com/Soul-Brews-Studio/oracle-v2) API.
+React dashboard for [arra-oracle](https://github.com/Soul-Brews-Studio/arra-oracle) API.
 
 ## Quick Start
 
@@ -8,7 +8,7 @@ React dashboard for [oracle-v2](https://github.com/Soul-Brews-Studio/oracle-v2) 
 bunx oracle-studio
 ```
 
-Serves the dashboard on http://localhost:3000, proxying API requests to oracle-v2 on port 47778.
+Serves the dashboard on http://localhost:3000, proxying API requests to arra-oracle on port 47778.
 
 ### Options
 
@@ -19,10 +19,10 @@ bunx oracle-studio --api http://host:47778  # custom API URL
 
 ## Development
 
-Start the oracle-v2 API server first:
+Start the arra-oracle API server first:
 
 ```bash
-# In your oracle-v2 repo
+# In your arra-oracle repo
 bun run server  # http://localhost:47778
 ```
 

--- a/bin/serve.ts
+++ b/bin/serve.ts
@@ -20,7 +20,7 @@ function getArg(flag: string, fallback: string): string {
 
 if (args.includes('--help') || args.includes('-h')) {
   console.log(`
-Oracle Studio — React dashboard for oracle-v2
+Oracle Studio — React dashboard for arra-oracle
 
 Usage:
   oracle-studio [options]
@@ -68,7 +68,7 @@ Bun.serve({
   async fetch(req) {
     const url = new URL(req.url);
 
-    // Proxy /api/* to oracle-v2
+    // Proxy /api/* to arra-oracle
     if (url.pathname.startsWith('/api/')) {
       const target = `${API_URL}${url.pathname}${url.search}`;
       const headers = new Headers(req.headers);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oracle-studio",
   "version": "0.8.0",
   "type": "module",
-  "description": "React dashboard for oracle-v2 API",
+  "description": "React dashboard for arra-oracle API",
   "bin": {
     "oracle-studio": "./bin/serve.ts"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { CommandPalette } from './components/CommandPalette';
 import { Map } from './pages/Map';
 import { Schedule } from './pages/Schedule';
 import { Pulse } from './pages/Pulse';
+import { Plugins } from './pages/Plugins';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { getStats } from './api/oracle';
 import { setVaultRepo } from './utils/docDisplay';
@@ -79,6 +80,7 @@ function AppContent() {
         <Route path="/traces/:id" element={<RequireAuth><Traces /></RequireAuth>} />
         <Route path="/superseded" element={<RequireAuth><Superseded /></RequireAuth>} />
         <Route path="/pulse" element={<RequireAuth><Pulse /></RequireAuth>} />
+        <Route path="/plugins" element={<RequireAuth><Plugins /></RequireAuth>} />
         <Route path="/schedule" element={<RequireAuth><Schedule /></RequireAuth>} />
         <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
       </Routes>

--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -261,6 +261,30 @@ export async function getFeed(opts?: { limit?: number; oracle?: string; event?: 
 }
 
 // ============================================================================
+// WASM Plugins API
+// ============================================================================
+
+export interface PluginInfo {
+  name: string;
+  file: string;
+  size: number;
+  modified: string;
+}
+
+export async function getPlugins(): Promise<{ plugins: PluginInfo[] }> {
+  const res = await fetch(`${API_BASE}/plugins`);
+  return res.json();
+}
+
+export async function loadPlugin(name: string): Promise<WebAssembly.Instance> {
+  const res = await fetch(`${API_BASE}/plugins/${name}`);
+  const bytes = await res.arrayBuffer();
+  const mod = await WebAssembly.compile(bytes);
+  const inst = await WebAssembly.instantiate(mod);
+  return inst;
+}
+
+// ============================================================================
 // Auth API
 // ============================================================================
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -234,7 +234,7 @@ export const CommandPalette = memo(function CommandPalette({ onClose }: CommandP
         {/* Footer */}
         <div className={styles.footer}>
           <span><kbd>Enter</kbd> search · <kbd>↑↓</kbd> navigate · <kbd>Esc</kbd> close · double-click → detail</span>
-          <span>oracle-v2</span>
+          <span>arra-oracle</span>
         </div>
       </div>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { path: '/search', label: 'Search' },
   { path: '/forum', label: 'Forum' },
   { path: '/pulse', label: 'Pulse' },
+  { path: '/plugins', label: 'Plugins' },
   { path: '/activity?tab=searches', label: 'Activity' },
 ] as const;
 

--- a/src/pages/Plugins.tsx
+++ b/src/pages/Plugins.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react';
+import { getPlugins, loadPlugin } from '../api/oracle';
+import type { PluginInfo } from '../api/oracle';
+
+export function Plugins() {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [active, setActive] = useState<{ name: string; instance: WebAssembly.Instance; exports: string[] } | null>(null);
+  const [output, setOutput] = useState<string[]>([]);
+  const [args, setArgs] = useState('');
+
+  useEffect(() => {
+    getPlugins().then(d => { setPlugins(d.plugins); setLoading(false); }).catch(() => setLoading(false));
+  }, []);
+
+  async function loadWasm(name: string) {
+    setOutput([`Loading ${name}.wasm...`]);
+    try {
+      const inst = await loadPlugin(name);
+      const exports = Object.keys(inst.exports);
+      setActive({ name, instance: inst, exports });
+      setOutput(prev => [...prev, `✓ Loaded. Exports: ${exports.join(', ')}`]);
+    } catch (e: any) {
+      setOutput(prev => [...prev, `✗ Failed: ${e.message}`]);
+    }
+  }
+
+  function callExport(fnName: string) {
+    if (!active) return;
+    const fn = active.instance.exports[fnName];
+    if (typeof fn !== 'function') {
+      setOutput(prev => [...prev, `${fnName} is not a function (${typeof fn})`]);
+      return;
+    }
+    const parsed = args.trim() ? args.split(',').map(s => {
+      const n = Number(s.trim());
+      return isNaN(n) ? s.trim() : n;
+    }) : [];
+    try {
+      const result = fn(...parsed);
+      setOutput(prev => [...prev, `${fnName}(${parsed.join(', ')}) → ${result}`]);
+    } catch (e: any) {
+      setOutput(prev => [...prev, `${fnName}(${parsed.join(', ')}) ✗ ${e.message}`]);
+    }
+  }
+
+  function readMemory() {
+    if (!active) return;
+    const mem = active.instance.exports.memory;
+    if (!(mem instanceof WebAssembly.Memory)) {
+      setOutput(prev => [...prev, 'No exported memory']);
+      return;
+    }
+    const bytes = new Uint8Array(mem.buffer);
+    // Find first null or read first 256 bytes
+    let end = 0;
+    while (end < 256 && bytes[end] !== 0) end++;
+    const text = new TextDecoder().decode(bytes.slice(0, end));
+    setOutput(prev => [...prev, `memory[0..${end}]: "${text}"`]);
+  }
+
+  function formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes}B`;
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-64px)] bg-[#0a0a0f]">
+      <div className="max-w-[960px] mx-auto px-6 py-6">
+        <div className="flex items-center gap-4 mb-6">
+          <h1 className="text-2xl font-bold text-white">WASM Plugins</h1>
+          <span className="text-sm font-mono text-white/40">{plugins.length} loaded</span>
+        </div>
+
+        {/* Plugin cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+          {loading && <div className="text-white/30 font-mono text-sm col-span-2">Loading...</div>}
+          {plugins.map(p => (
+            <button
+              key={p.name}
+              onClick={() => loadWasm(p.name)}
+              className={`text-left px-5 py-4 rounded-xl border transition-all cursor-pointer ${
+                active?.name === p.name
+                  ? 'border-[#64b5f6]/40 bg-[#64b5f6]/10'
+                  : 'border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.06]'
+              }`}
+            >
+              <div className="flex items-center gap-3 mb-1.5">
+                <span className="text-base font-mono font-bold text-white">{p.name}</span>
+                <span className="text-[10px] font-mono text-white/30 ml-auto">{formatSize(p.size)}</span>
+              </div>
+              <div className="text-xs font-mono text-white/35">{p.file}</div>
+            </button>
+          ))}
+          {!loading && plugins.length === 0 && (
+            <div className="text-white/20 font-mono text-sm col-span-2">
+              No plugins found. Place .wasm files in ~/.oracle/plugins/
+            </div>
+          )}
+        </div>
+
+        {/* Active plugin console */}
+        {active && (
+          <div className="rounded-xl border border-white/[0.08] overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center gap-3 px-5 py-3 border-b border-white/[0.06]">
+              <span className="w-2.5 h-2.5 rounded-full bg-emerald-400 animate-pulse" />
+              <span className="font-mono font-bold text-white">{active.name}.wasm</span>
+              <span className="text-xs font-mono text-white/30">
+                {active.exports.filter(e => e !== 'memory').length} functions
+              </span>
+            </div>
+
+            {/* Export buttons */}
+            <div className="flex items-center gap-2 px-5 py-3 border-b border-white/[0.06] flex-wrap">
+              {active.exports.map(name => (
+                <button
+                  key={name}
+                  onClick={() => name === 'memory' ? readMemory() : callExport(name)}
+                  className="px-3 py-1.5 rounded-lg text-xs font-mono font-bold border border-[#64b5f6]/30 text-[#64b5f6] bg-[#64b5f6]/10 hover:bg-[#64b5f6]/20 transition-all cursor-pointer"
+                >
+                  {name === 'memory' ? '🧠 read memory' : `${name}()`}
+                </button>
+              ))}
+            </div>
+
+            {/* Args input */}
+            <div className="flex items-center gap-2 px-5 py-2.5 border-b border-white/[0.06]">
+              <span className="text-xs font-mono text-white/40">args:</span>
+              <input
+                type="text"
+                value={args}
+                onChange={e => setArgs(e.target.value)}
+                placeholder="7, 8"
+                className="flex-1 bg-transparent border-none outline-none text-sm font-mono text-white placeholder:text-white/20 [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
+                style={{ WebkitAppearance: 'none' } as React.CSSProperties}
+                inputMode="text"
+              />
+            </div>
+
+            {/* Output console */}
+            <div className="px-5 py-4 max-h-[400px] overflow-auto font-mono text-sm leading-relaxed">
+              {output.map((line, i) => (
+                <div key={i} className={`${
+                  line.startsWith('✓') ? 'text-emerald-400'
+                  : line.startsWith('✗') ? 'text-red-400'
+                  : line.includes('→') ? 'text-[#64b5f6]'
+                  : 'text-white/50'
+                }`}>
+                  {line}
+                </div>
+              ))}
+              {output.length === 0 && (
+                <span className="text-white/20">Click a function to call it</span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ function oracleAutoStart() {
     configureServer() {
       try {
         execSync('bun run server:ensure', {
-          cwd: resolve(__dirname, '../oracle-v2'),
+          cwd: resolve(__dirname, '../arra-oracle'),
           timeout: 15000,
           stdio: 'pipe',
         })


### PR DESCRIPTION
Two commits bundled (user's request — one bigger PR instead of splitting):

## Commit 1: `rebrand: oracle-v2 → arra-oracle`
The identity rebrand Nat started.

## Commit 2: `feat(plugins): WASM plugin console at /plugins`
New `/plugins` page:
- Cards listing `*.wasm` from backend (`GET /api/plugins`)
- Click → `WebAssembly.instantiate`, show exports
- Click an export → call it with comma-separated args
- Read exported memory as text

Backend companion: https://github.com/Soul-Brews-Studio/arra-oracle-v3/pull/847 (/api/plugins endpoints) + https://github.com/Soul-Brews-Studio/arra-oracle-v3/pull/846 (PNA CORS so deployed studio reaches localhost:47778)

## Verify

1. Merge arra-oracle-v3 PRs #846 and #847, drop a `.wasm` in `~/.oracle/plugins/`, restart local v3 server
2. Run `bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio` → http://localhost:3000/plugins renders cards
3. OR deploy: https://studio.buildwithoracle.com/plugins reaches local :47778 once PNA CORS lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)