### PR TITLE
fix(worker): JSON 404 on /api/* for deployed studio

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -1,0 +1,25 @@
+interface Env {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+}
+
+const HELP = {
+  error: "API not available on deployed studio",
+  message:
+    "studio.buildwithoracle.com is a static preview — the API backend only runs locally. " +
+    "Install + run: `bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio` " +
+    "(and `bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3` for the MCP server).",
+  docs: "https://neo.buildwithoracle.com/install/",
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname.startsWith("/api/") || url.pathname === "/api") {
+      return Response.json(HELP, {
+        status: 404,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,18 @@
+{
+  "name": "oracle-studio",
+  "main": "worker.ts",
+  "compatibility_date": "2025-06-01",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "studio.buildwithoracle.com",
+      "custom_domain": true
+    }
+  ],
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application"
+  }
+}

--- a/wrangler.preview.json
+++ b/wrangler.preview.json
@@ -1,0 +1,12 @@
+{
+  "name": "oracle-studio-preview",
+  "main": "worker.ts",
+  "compatibility_date": "2025-06-01",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
+  "workers_dev": true,
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
Deployed studio was returning index.html for /api/* paths, breaking all React fetch().json() calls. New Workers script returns a helpful JSON 404 pointing at `bunx oracle-studio` instead.