### PR TITLE
feat(api): deployed studio targets localhost:47778 by default

### DIFF
--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -1,6 +1,13 @@
 // Oracle API client
-// Always use /api prefix (backend routes are under /api/*)
-const API_BASE = '/api';
+//
+// API_BASE resolution:
+// 1. VITE_API_BASE env (set at build time) — explicit override
+// 2. Production build → http://localhost:47778/api (deployed studio connects
+//    to the user's local MCP via Private Network Access CORS)
+// 3. Dev → /api (vite proxy or bunx serve.ts proxy forwards to :47778)
+const API_BASE =
+  (import.meta.env.VITE_API_BASE as string | undefined) ??
+  (import.meta.env.PROD ? 'http://localhost:47778/api' : '/api');
 
 /** Strip project prefix from source_file for display (vault-indexed cross-project docs) */
 export function stripProjectPrefix(sourceFile: string, project?: string): string {


### PR DESCRIPTION
Root cause of deployed studio 404s: hardcoded `API_BASE='/api'` → all fetches go to the Cloudflare origin, which returns our helpful install-locally 404.

Fix: for PROD builds, default API_BASE to `http://localhost:47778/api`. Dev stays on `/api` (vite proxy).

Pair with arra-oracle-v3 PR #849 (PNA CORS) — both needed for Chrome to allow the cross-origin fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)