### PR TITLE
chore: remove dev-server autostart of oracle backend

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,27 +13,8 @@ const gitHash = (() => {
 })()
 const appVersion = `v${pkg.version}+${gitHash}`
 
-// Auto-start Oracle backend when dev server starts
-function oracleAutoStart() {
-  return {
-    name: 'oracle-auto-start',
-    configureServer() {
-      try {
-        execSync('bun run server:ensure', {
-          cwd: resolve(__dirname, '../arra-oracle'),
-          timeout: 15000,
-          stdio: 'pipe',
-        })
-        console.log('🔮 Oracle backend ready')
-      } catch {
-        console.warn('⚠️  Could not auto-start Oracle backend')
-      }
-    },
-  }
-}
-
 export default defineConfig({
-  plugins: [tailwindcss(), react(), oracleAutoStart()],
+  plugins: [tailwindcss(), react()],
   define: {
     __APP_VERSION__: JSON.stringify(appVersion)
   },


### PR DESCRIPTION
Drop the oracleAutoStart plugin. Assumed sibling checkout, silently failed, surprised users. Dev proxy still forwards /api to $ORACLE_API_URL or localhost:47778.

🤖 Generated with Claude Code