### PR TITLE
fix(api): route ALL /api/ fetches through API_BASE

### DIFF
--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -5,7 +5,7 @@
 // 2. Production build → http://localhost:47778/api (deployed studio connects
 //    to the user's local MCP via Private Network Access CORS)
 // 3. Dev → /api (vite proxy or bunx serve.ts proxy forwards to :47778)
-const API_BASE =
+export const API_BASE =
   (import.meta.env.VITE_API_BASE as string | undefined) ??
   (import.meta.env.PROD ? 'http://localhost:47778/api' : '/api');
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { API_BASE } from '../api/oracle';
 
 const navItems = [
   { path: '/', label: 'Overview' },
@@ -42,7 +43,7 @@ export function Header() {
 
   async function loadStats() {
     try {
-      const res = await fetch(`/api/session/stats?since=${sessionStart}`);
+      const res = await fetch(`${API_BASE}/session/stats?since=${sessionStart}`);
       if (res.ok) {
         const data = await res.json();
         setStats({ searches: data.searches, learnings: data.learnings });

--- a/src/pages/DocDetail.tsx
+++ b/src/pages/DocDetail.tsx
@@ -2,7 +2,7 @@ import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { useState, useEffect, useCallback } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { list, getFile, getDoc } from '../api/oracle';
+import { list, getFile, getDoc, API_BASE } from '../api/oracle';
 import type { Document } from '../api/oracle';
 import { SidebarLayout } from '../components/SidebarLayout';
 import { getDocDisplayInfo } from '../utils/docDisplay';
@@ -154,7 +154,7 @@ export function DocDetail() {
     if (!doc?.source_file) return;
 
     try {
-      const res = await fetch(`/api/file?path=${encodeURIComponent(doc.source_file)}${doc.project ? `&project=${encodeURIComponent(doc.project)}` : ''}`);
+      const res = await fetch(`${API_BASE}/file?path=${encodeURIComponent(doc.source_file)}${doc.project ? `&project=${encodeURIComponent(doc.project)}` : ''}`);
       if (res.ok) {
         const content = await res.text();
         setRawContent(content);

--- a/src/pages/Evolution.tsx
+++ b/src/pages/Evolution.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
+import { API_BASE } from '../api/oracle';
 
 const EVOLUTION_FILTERS = [
   { key: 'all', label: 'All' },
@@ -44,7 +45,7 @@ export function Evolution() {
   async function loadSupersessions() {
     setLoading(true);
     try {
-      const res = await fetch('/api/supersede');
+      const res = await fetch(`${API_BASE}/supersede`);
       const data: SupersedeResponse = await res.json();
       setSupersessions(data.supersessions);
       setTotal(data.total);

--- a/src/pages/Handoff.tsx
+++ b/src/pages/Handoff.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Markdown from 'react-markdown';
 import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
+import { API_BASE } from '../api/oracle';
 
 interface HandoffFile {
   filename: string;
@@ -50,7 +51,7 @@ export function Handoff() {
     setLoadingContent(true);
 
     try {
-      const res = await fetch(`/api/file?path=${encodeURIComponent(file.path)}`);
+      const res = await fetch(`${API_BASE}/file?path=${encodeURIComponent(file.path)}`);
       if (res.ok) {
         const text = await res.text();
         setFullContent(text);

--- a/src/pages/Superseded.tsx
+++ b/src/pages/Superseded.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
 import { getDocDisplayInfo } from '../utils/docDisplay';
+import { API_BASE } from '../api/oracle';
 
 const TYPE_FILTERS = [
   { key: 'all', label: 'All' },
@@ -47,7 +48,7 @@ export function Superseded() {
   async function loadLogs() {
     setLoading(true);
     try {
-      const res = await fetch(`/api/supersede?limit=${limit}&offset=${page * limit}`);
+      const res = await fetch(`${API_BASE}/supersede?limit=${limit}&offset=${page * limit}`);
       const data: SupersedeResponse = await res.json();
       setLogs(data.supersessions || []);
       setTotal(data.total || 0);

--- a/src/pages/Traces.tsx
+++ b/src/pages/Traces.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
 import { getDocDisplayInfo } from '../utils/docDisplay';
 import { Spinner } from '../components/ui/Spinner';
+import { API_BASE } from '../api/oracle';
 
 interface TraceSummary {
   traceId: string;
@@ -107,7 +108,7 @@ export function Traces() {
     try {
       const params = new URLSearchParams({ limit: '100' });
       if (statusFilter !== 'all') params.set('status', statusFilter);
-      const res = await fetch(`/api/traces?${params}`);
+      const res = await fetch(`${API_BASE}/traces?${params}`);
       const data: TracesResponse = await res.json();
       setTraces(data.traces);
       setTotal(data.total);
@@ -121,7 +122,7 @@ export function Traces() {
   async function loadTraceDetail(traceId: string) {
     setLoading(true);
     try {
-      const res = await fetch(`/api/traces/${traceId}`);
+      const res = await fetch(`${API_BASE}/traces/${traceId}`);
       if (!res.ok) {
         navigate('/traces');
         return;
@@ -138,7 +139,7 @@ export function Traces() {
 
   async function loadLinkedChain(traceId: string) {
     try {
-      const res = await fetch(`/api/traces/${traceId}/linked-chain`);
+      const res = await fetch(`${API_BASE}/traces/${traceId}/linked-chain`);
       if (res.ok) {
         const data = await res.json();
         setLinkedChain(data.chain || []);
@@ -153,7 +154,7 @@ export function Traces() {
   async function loadFamilyChain(traceId: string) {
     try {
       // Fetch current trace to get parent/children info
-      const res = await fetch(`/api/traces/${traceId}`);
+      const res = await fetch(`${API_BASE}/traces/${traceId}`);
       if (!res.ok) return;
       const current: TraceDetail = await res.json();
 
@@ -161,7 +162,7 @@ export function Traces() {
 
       // Fetch parent if exists
       if (current.parentTraceId) {
-        const parentRes = await fetch(`/api/traces/${current.parentTraceId}`);
+        const parentRes = await fetch(`${API_BASE}/traces/${current.parentTraceId}`);
         if (parentRes.ok) {
           const parent: TraceDetail = await parentRes.json();
           family.push(parent);
@@ -174,7 +175,7 @@ export function Traces() {
       // Fetch children
       if (current.childTraceIds && current.childTraceIds.length > 0) {
         for (const childId of current.childTraceIds) {
-          const childRes = await fetch(`/api/traces/${childId}`);
+          const childRes = await fetch(`${API_BASE}/traces/${childId}`);
           if (childRes.ok) {
             const child: TraceDetail = await childRes.json();
             family.push(child);
@@ -184,13 +185,13 @@ export function Traces() {
 
       // Also check if current is a child and has siblings
       if (current.parentTraceId) {
-        const parentRes = await fetch(`/api/traces/${current.parentTraceId}`);
+        const parentRes = await fetch(`${API_BASE}/traces/${current.parentTraceId}`);
         if (parentRes.ok) {
           const parent: TraceDetail = await parentRes.json();
           // Add siblings (other children of parent)
           for (const siblingId of parent.childTraceIds || []) {
             if (siblingId !== traceId && !family.some(f => f.traceId === siblingId)) {
-              const sibRes = await fetch(`/api/traces/${siblingId}`);
+              const sibRes = await fetch(`${API_BASE}/traces/${siblingId}`);
               if (sibRes.ok) {
                 const sibling: TraceDetail = await sibRes.json();
                 family.push(sibling);
@@ -246,7 +247,7 @@ export function Traces() {
       // First try direct file read
       const params = new URLSearchParams({ path });
       if (project) params.set('project', project);
-      const res = await fetch(`/api/file?${params}`);
+      const res = await fetch(`${API_BASE}/file?${params}`);
       if (res.ok) {
         const text = await res.text();
         if (text && !text.startsWith('File not found')) {
@@ -257,7 +258,7 @@ export function Traces() {
 
       // Search Oracle for related content (use last part of path or repo name)
       const searchTerm = path.split('/').pop()?.replace('.md', '') || path.split('/').slice(-1)[0] || '';
-      const searchRes = await fetch(`/api/search?q=${encodeURIComponent(searchTerm)}&limit=1`);
+      const searchRes = await fetch(`${API_BASE}/search?q=${encodeURIComponent(searchTerm)}&limit=1`);
       if (searchRes.ok) {
         const searchData = await searchRes.json();
         if (searchData.results?.[0]) {
@@ -274,7 +275,7 @@ export function Traces() {
       // Also try searching for the full path/repo name
       if (!fileConcepts.length) {
         const repoName = path.replace(/\//g, ' ');
-        const repoSearchRes = await fetch(`/api/search?q=${encodeURIComponent(repoName)}&limit=1`);
+        const repoSearchRes = await fetch(`${API_BASE}/search?q=${encodeURIComponent(repoName)}&limit=1`);
         if (repoSearchRes.ok) {
           const repoData = await repoSearchRes.json();
           if (repoData.results?.[0]?.concepts) {


### PR DESCRIPTION
PR #5 only fixed the oracle.ts client. 21 more fetch(\`/api/...\`) calls across 6 files still went same-origin → CF Worker 404 → runtime errors on deployed studio.

All call sites now import API_BASE from api/oracle and use \`\${API_BASE}/...\`.

Verified bundle:
\`\`\`
$ grep -c 'localhost:47778/api' dist/assets/index-*.js
1   # single deduplicated constant, all fetches reference it
\`\`\`

Closes the runtime error cascade from 2026-04-19 console paste.

🤖 Generated with Claude Code