### PR TITLE
feat(api): ?host= URL param pattern (maw-ui port)

### DIFF
--- a/src/api/host.ts
+++ b/src/api/host.ts
@@ -1,0 +1,103 @@
+/**
+ * Host resolution — ported from maw-ui's src/lib/api.ts (local.drizzle.studio pattern).
+ *
+ * User visits studio.buildwithoracle.com/?host=localhost:47778 (or any host:port,
+ * or full http:// / https:// URL). The host is saved to localStorage and the URL
+ * is cleaned. All subsequent fetches go through apiUrl(path) which prepends the
+ * saved host.
+ *
+ * Three accepted forms for ?host=:
+ *   ?host=localhost:47778              → http://localhost:47778 (bare host:port defaults to http
+ *                                         because arra-oracle-v3 serves plain HTTP by default)
+ *   ?host=http://oracle-world:47778    → http://oracle-world:47778 (explicit, same result)
+ *   ?host=https://mba.wg:47778         → https://mba.wg:47778 (if user has mkcert or TLS setup)
+ *
+ * No stored host → same-origin (useful when studio is served from the same MCP).
+ */
+
+const STORAGE_KEY = 'oracle-studio-host';
+const RECENT_KEY = 'oracle-studio-host-recent';
+const RECENT_LIMIT = 8;
+
+const params = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : new URLSearchParams();
+const urlHost = params.get('host');
+
+// Auto-persist: ?host= in URL → save to localStorage → redirect clean
+if (urlHost && typeof window !== 'undefined') {
+  localStorage.setItem(STORAGE_KEY, urlHost);
+  addRecentHost(urlHost);
+  const url = new URL(window.location.href);
+  url.searchParams.delete('host');
+  window.location.replace(url.toString());
+}
+
+const hostParam = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+
+export const isRemote = !!hostParam;
+export const activeHost: string | null = hostParam;
+
+export function getStoredHost(): string | null {
+  return typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+}
+
+export function setStoredHost(host: string): void {
+  localStorage.setItem(STORAGE_KEY, host);
+  addRecentHost(host);
+}
+
+export function clearStoredHost(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function getRecentHosts(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function addRecentHost(host: string): void {
+  const recent = getRecentHosts().filter((h) => h !== host);
+  recent.unshift(host);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(recent.slice(0, RECENT_LIMIT)));
+}
+
+function resolveHost(): { httpProto: string; wsProto: string; host: string } | null {
+  if (!hostParam) return null;
+  if (hostParam.startsWith('https://')) {
+    return {
+      httpProto: 'https:',
+      wsProto: 'wss:',
+      host: hostParam.slice('https://'.length).replace(/\/+$/, ''),
+    };
+  }
+  if (hostParam.startsWith('http://')) {
+    return {
+      httpProto: 'http:',
+      wsProto: 'ws:',
+      host: hostParam.slice('http://'.length).replace(/\/+$/, ''),
+    };
+  }
+  // Bare host:port — default to http because arra-oracle-v3 serves plain HTTP.
+  // Chrome's Private Network Access CORS allows this from https origins.
+  return { httpProto: 'http:', wsProto: 'ws:', host: hostParam.replace(/\/+$/, '') };
+}
+
+/** Build a full URL for fetch(). Accepts an `/api/...` path and prepends the configured host. */
+export function apiUrl(path: string): string {
+  const r = resolveHost();
+  if (!r) return path;
+  return `${r.httpProto}//${r.host}${path}`;
+}
+
+/** WebSocket URL builder. */
+export function wsUrl(path: string): string {
+  const r = resolveHost();
+  if (!r) {
+    const proto = typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = typeof window !== 'undefined' ? window.location.host : 'localhost';
+    return `${proto}//${host}${path}`;
+  }
+  return `${r.wsProto}//${r.host}${path}`;
+}

--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -1,13 +1,16 @@
 // Oracle API client
 //
-// API_BASE resolution:
-// 1. VITE_API_BASE env (set at build time) — explicit override
-// 2. Production build → http://localhost:47778/api (deployed studio connects
-//    to the user's local MCP via Private Network Access CORS)
-// 3. Dev → /api (vite proxy or bunx serve.ts proxy forwards to :47778)
-export const API_BASE =
-  (import.meta.env.VITE_API_BASE as string | undefined) ??
-  (import.meta.env.PROD ? 'http://localhost:47778/api' : '/api');
+// Host resolution follows the maw-ui / local.drizzle.studio pattern:
+// - ?host=localhost:47778 on load → saved to localStorage, URL redirected clean
+// - No stored host → same-origin `/api` (dev via vite proxy, or studio served by a local MCP)
+// - Stored host → prepended to every request, e.g. https://mba.wg:47778/api
+//
+// See ./host.ts for the full API (setStoredHost, clearStoredHost, getRecentHosts, wsUrl…).
+import { apiUrl } from './host';
+export { apiUrl } from './host';
+
+/** Resolved base for Oracle API (e.g. `/api` or `https://mba.wg:47778/api`). */
+export const API_BASE = apiUrl('/api');
 
 /** Strip project prefix from source_file for display (vault-indexed cross-project docs) */
 export function stripProjectPrefix(sourceFile: string, project?: string): string {


### PR DESCRIPTION
Ports maw-ui / local.drizzle.studio host pattern.

**Usage**: `https://studio.buildwithoracle.com/?host=localhost:47778` → saved to localStorage → all fetches prepend host.

**Supersedes PR #5's** hardcoded PROD=localhost:47778 default — now user-controlled via URL param.

**New module**: src/api/host.ts (apiUrl, wsUrl, getStoredHost, setStoredHost, clearStoredHost, getRecentHosts).

**Call sites unchanged**: API_BASE kept as alias for `apiUrl('/api')` — the 21 fetch(\`\${API_BASE}/xxx\`) calls continue to work, now with user-configurable host.

Next issue: Connect UI (enter host + choose from recent list) → follow-up.

🤖 Generated with Claude Code