### PR TITLE
feat(host): localhost default + header indicator + quick-switch

### DIFF
--- a/src/api/host.ts
+++ b/src/api/host.ts
@@ -18,6 +18,7 @@
 const STORAGE_KEY = 'oracle-studio-host';
 const RECENT_KEY = 'oracle-studio-host-recent';
 const RECENT_LIMIT = 8;
+const DEFAULT_HOST = 'http://localhost:47778';
 
 const params = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : new URLSearchParams();
 const urlHost = params.get('host');
@@ -31,10 +32,14 @@ if (urlHost && typeof window !== 'undefined') {
   window.location.replace(url.toString());
 }
 
-const hostParam = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+// Resolution: stored host > DEFAULT_HOST (localhost:47778).
+// Always resolves to *some* host; users can override via ?host= in the URL.
+const storedHost = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+const hostParam = storedHost ?? DEFAULT_HOST;
 
-export const isRemote = !!hostParam;
-export const activeHost: string | null = hostParam;
+export const isRemote = !!storedHost;
+export const isDefault = !storedHost;
+export const activeHost: string = hostParam;
 
 export function getStoredHost(): string | null {
   return typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
@@ -63,8 +68,7 @@ function addRecentHost(host: string): void {
   localStorage.setItem(RECENT_KEY, JSON.stringify(recent.slice(0, RECENT_LIMIT)));
 }
 
-function resolveHost(): { httpProto: string; wsProto: string; host: string } | null {
-  if (!hostParam) return null;
+function resolveHost(): { httpProto: string; wsProto: string; host: string } {
   if (hostParam.startsWith('https://')) {
     return {
       httpProto: 'https:',
@@ -87,17 +91,18 @@ function resolveHost(): { httpProto: string; wsProto: string; host: string } | n
 /** Build a full URL for fetch(). Accepts an `/api/...` path and prepends the configured host. */
 export function apiUrl(path: string): string {
   const r = resolveHost();
-  if (!r) return path;
   return `${r.httpProto}//${r.host}${path}`;
 }
 
 /** WebSocket URL builder. */
 export function wsUrl(path: string): string {
   const r = resolveHost();
-  if (!r) {
-    const proto = typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const host = typeof window !== 'undefined' ? window.location.host : 'localhost';
-    return `${proto}//${host}${path}`;
-  }
   return `${r.wsProto}//${r.host}${path}`;
+}
+
+/** Human-readable host label for UI (`localhost:47778 (default)` or `mba.wg:47778`). */
+export function hostLabel(): string {
+  const r = resolveHost();
+  const withoutProto = `${r.host}`;
+  return isDefault ? `${withoutProto} (default)` : withoutProto;
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { API_BASE } from '../api/oracle';
+import { hostLabel, isDefault, setStoredHost, clearStoredHost } from '../api/host';
 
 const navItems = [
   { path: '/', label: 'Overview' },
@@ -69,6 +70,27 @@ export function Header() {
 
         {/* Session stats - moved here */}
         <div className="flex items-center gap-3 text-xs text-text-muted font-mono shrink-0">
+          <button
+            onClick={() => {
+              const next = window.prompt(
+                'Oracle host (leave empty to use default localhost:47778):\n\nExamples:\n  localhost:47778\n  http://mba.wg:47778\n  https://oracle.example.com',
+                isDefault ? '' : hostLabel().replace(' (default)', '')
+              );
+              if (next === null) return;
+              if (next.trim() === '') clearStoredHost();
+              else setStoredHost(next.trim());
+              window.location.reload();
+            }}
+            title={`Click to change host. Currently: ${hostLabel()}`}
+            className={`flex items-center gap-1.5 px-2 py-0.5 rounded-md border transition-all duration-150 ${
+              isDefault
+                ? 'border-border text-text-muted hover:bg-bg-card'
+                : 'border-accent/40 bg-accent/10 text-accent hover:bg-accent/20'
+            }`}
+          >
+            <span className={`w-1.5 h-1.5 rounded-full ${isDefault ? 'bg-text-muted' : 'bg-accent animate-pulse'}`} />
+            <span>{hostLabel()}</span>
+          </button>
           <span>{duration}</span>
           <span>{stats.searches}s</span>
           <span>{stats.learnings}l</span>


### PR DESCRIPTION
Follows #10. Always resolves to a host (defaults to localhost:47778 if none stored) and surfaces it in the header.

- Header shows current host as a pill button:
  - greyed 'localhost:47778 (default)' when default
  - accent-glowing 'mba.wg:47778' when user-set
- Click → window.prompt to enter a new host; empty → clear + use default
- Keeps ?host= URL param intercept from #10

🤖 Generated with Claude Code