### PR TITLE
fix(api): route Forum/Schedule/Handoff through API_BASE

### DIFF
--- a/src/pages/Forum.tsx
+++ b/src/pages/Forum.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Spinner } from '../components/ui/Spinner';
+import { API_BASE } from '../api/oracle';
 
 interface Thread {
   id: number;
@@ -25,8 +26,6 @@ interface ThreadDetail {
   thread: { id: number; title: string; status: string; created_at: string; issue_url: string | null };
   messages: Message[];
 }
-
-const API_BASE = '/api';
 
 const STATUS_COLORS: Record<string, string> = {
   answered: '#4ade80',

--- a/src/pages/Handoff.tsx
+++ b/src/pages/Handoff.tsx
@@ -26,7 +26,7 @@ export function Handoff() {
   async function loadInbox() {
     setLoading(true);
     try {
-      const res = await fetch('/api/inbox?limit=50');
+      const res = await fetch(`${API_BASE}/inbox?limit=50`);
       if (res.ok) {
         const data = await res.json();
         setFiles(data.files || []);

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -2,8 +2,7 @@ import { useState, useEffect } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { SidebarLayout, TOOLS_NAV } from '../components/SidebarLayout';
-
-const API_BASE = '/api';
+import { API_BASE } from '../api/oracle';
 
 export function Schedule() {
   const [content, setContent] = useState('');


### PR DESCRIPTION
Three files PR #9 missed — each had a shadowing local const API_BASE = '/api'. Closes the /forum 404 cascade in deployed studio.