### PR TITLE
feat(worker): vector-playground.buildwithoracle.com routes to /playground

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -20,6 +20,14 @@ export default {
         headers: { "cache-control": "no-store" },
       });
     }
+    if (
+      url.hostname === "vector-playground.buildwithoracle.com" &&
+      (url.pathname === "/" || url.pathname === "/index.html")
+    ) {
+      const rewritten = new URL(request.url);
+      rewritten.pathname = "/playground";
+      return env.ASSETS.fetch(new Request(rewritten.toString(), request));
+    }
     return env.ASSETS.fetch(request);
   },
 };

--- a/wrangler.json
+++ b/wrangler.json
@@ -8,6 +8,10 @@
     {
       "pattern": "studio.buildwithoracle.com",
       "custom_domain": true
+    },
+    {
+      "pattern": "vector-playground.buildwithoracle.com",
+      "custom_domain": true
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary
- Adds `vector-playground.buildwithoracle.com` as a new custom domain route in `wrangler.json`
- Worker rewrites `/` and `/index.html` on that hostname to `/playground` before calling `env.ASSETS.fetch`
- All other paths (assets, nested routes) pass through unchanged so the SPA loads correctly

## Notes
- DNS: CNAME for `vector-playground.buildwithoracle.com` may need to be added via Cloudflare dashboard before custom-domain route resolves.
- Lead will deploy after merge (not deploying from this branch).

## Test plan
- [ ] `bun run build` passes (verified locally)
- [ ] After deploy, `https://vector-playground.buildwithoracle.com/` serves the playground page
- [ ] `https://vector-playground.buildwithoracle.com/assets/...` still serves SPA assets
- [ ] `https://studio.buildwithoracle.com/` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)