### PR TITLE
remove: vector.* routes (extracted to ui-vector-oracle-studio)

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -20,18 +20,6 @@ export default {
         headers: { "cache-control": "no-store" },
       });
     }
-    const VECTOR_HOSTS = new Set([
-      "vector.buildwithoracle.com",
-      "vector-playground.buildwithoracle.com",
-    ]);
-    if (
-      VECTOR_HOSTS.has(url.hostname) &&
-      (url.pathname === "/" || url.pathname === "/index.html")
-    ) {
-      const rewritten = new URL(request.url);
-      rewritten.pathname = "/playground";
-      return env.ASSETS.fetch(new Request(rewritten.toString(), request));
-    }
     return env.ASSETS.fetch(request);
   },
 };

--- a/wrangler.json
+++ b/wrangler.json
@@ -8,14 +8,6 @@
     {
       "pattern": "studio.buildwithoracle.com",
       "custom_domain": true
-    },
-    {
-      "pattern": "vector-playground.buildwithoracle.com",
-      "custom_domain": true
-    },
-    {
-      "pattern": "vector.buildwithoracle.com",
-      "custom_domain": true
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary

Vector playground extracted to its own repo: `Soul-Brews-Studio/ui-vector-oracle-studio`.

- Drop `VECTOR_HOSTS` rewrite block from `worker.ts` (lines 23-34 of the pre-change file)
- Remove the two vector `custom_domain` entries from `wrangler.json` routes:
  - `vector.buildwithoracle.com`
  - `vector-playground.buildwithoracle.com`

Once this merges and deploys, the new worker (`vector-oracle-studio`) will claim those routes.

New bundle is already live at `https://vector-oracle-studio.laris.workers.dev` (workers_dev).

Refs #28

## Test plan

- [ ] CI green
- [ ] After merge + deploy: `curl -sI https://studio.buildwithoracle.com/` still 200 from studio
- [ ] After phase C: `curl -sI https://vector.buildwithoracle.com/` 200 from new bundle (different content-hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)