### PR TITLE
feat: local.buildwithoracle.com subdomain

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -8,6 +8,10 @@
     {
       "pattern": "studio.buildwithoracle.com",
       "custom_domain": true
+    },
+    {
+      "pattern": "local.buildwithoracle.com",
+      "custom_domain": true
     }
   ],
   "assets": {


### PR DESCRIPTION
Adds `local.buildwithoracle.com` as a second custom-domain route serving the same ui-studio-oracle-studio bundle as `studio.buildwithoracle.com`. Intended for dev surface pointing to localhost backend.