### PR TITLE
feat(menu): drag-drop reorder

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "oracle-studio",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@types/three": "^0.182.0",
         "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
         "ml5": "1",
@@ -74,6 +77,14 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test:ui": "bunx playwright test --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@types/three": "^0.182.0",
     "knowledge-map-3d": "github:Bombbaza/Multi-Planet-System-Knowledge-Map-3D",
     "ml5": "1",

--- a/src/pages/MenuEditor.tsx
+++ b/src/pages/MenuEditor.tsx
@@ -1,5 +1,22 @@
 import { useEffect, useState } from 'react';
 import { API_BASE } from '../api/oracle';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 interface MenuItem {
   id: number;
@@ -30,11 +47,78 @@ const SOURCE_COLORS: Record<string, string> = {
   custom: 'bg-pink-500/10 text-pink-300',
 };
 
+function SortableRow({
+  item,
+  onPatch,
+  onReset,
+  onDelete,
+}: {
+  item: MenuItem;
+  onPatch: (id: number, patch: Partial<MenuItem>) => void;
+  onReset: (id: number) => void;
+  onDelete: (id: number) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 px-3 py-2 rounded-lg bg-bg-elevated border border-border hover:border-accent/30 transition"
+    >
+      <span
+        {...attributes}
+        {...listeners}
+        className="cursor-grab active:cursor-grabbing text-text-secondary hover:text-accent select-none px-1"
+        title="Drag to reorder"
+      >
+        ⋮⋮
+      </span>
+      <input
+        type="checkbox"
+        checked={item.enabled}
+        onChange={(e) => onPatch(item.id, { enabled: e.target.checked })}
+        className="w-4 h-4"
+        title="Enabled"
+      />
+      <span className="text-xs text-text-secondary font-mono w-10">#{item.position}</span>
+      <input
+        type="text"
+        defaultValue={item.label}
+        onBlur={(e) => { if (e.target.value !== item.label) onPatch(item.id, { label: e.target.value }); }}
+        className="bg-transparent border-b border-transparent hover:border-border focus:border-accent focus:outline-none px-1 font-medium flex-none w-40"
+      />
+      <code className="text-xs text-text-secondary font-mono flex-1 truncate">{item.path}</code>
+      <span className={`px-2 py-0.5 rounded text-[10px] ${SOURCE_COLORS[item.source] ?? ''}`}>{item.source}</span>
+      {item.touchedAt && (
+        <span className="px-2 py-0.5 rounded text-[10px] bg-amber-500/10 text-amber-300 border border-amber-500/20">edited</span>
+      )}
+      <select
+        value={item.groupKey}
+        onChange={(e) => onPatch(item.id, { groupKey: e.target.value })}
+        className="bg-bg-base border border-border rounded px-2 py-1 text-xs"
+      >
+        {GROUPS.map((g) => <option key={g} value={g}>{g}</option>)}
+      </select>
+      {item.touchedAt && item.source === 'route' && (
+        <button onClick={() => onReset(item.id)} className="text-xs text-text-secondary hover:text-accent" title="Reset">reset</button>
+      )}
+      <button onClick={() => onDelete(item.id)} className="text-xs text-text-secondary hover:text-red-400" title="Delete">✕</button>
+    </div>
+  );
+}
+
 export function MenuEditor() {
   const [items, setItems] = useState<MenuItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }));
 
   async function load() {
     setLoading(true);
@@ -53,72 +137,62 @@ export function MenuEditor() {
 
   useEffect(() => { load(); }, []);
 
-  function showToast(msg: string) {
-    setToast(msg);
-    setTimeout(() => setToast(null), 2500);
-  }
+  function showToast(msg: string) { setToast(msg); setTimeout(() => setToast(null), 2500); }
 
   async function patchItem(id: number, patch: Partial<MenuItem>) {
     try {
-      const res = await fetch(`${API_BASE}/menu/items/${id}`, {
-        method: 'PATCH',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(patch),
-      });
+      const res = await fetch(`${API_BASE}/menu/items/${id}`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify(patch) });
       if (!res.ok) throw new Error(`patch ${res.status}`);
-      showToast('Saved');
-      await load();
-    } catch (e) {
-      showToast(`Error: ${e instanceof Error ? e.message : e}`);
-    }
+      showToast('Saved'); await load();
+    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
-
   async function resetItem(id: number) {
     try {
       const res = await fetch(`${API_BASE}/menu/reset/${id}`, { method: 'POST' });
       if (!res.ok) throw new Error(`reset ${res.status}`);
-      showToast('Reset to default');
-      await load();
-    } catch (e) {
-      showToast(`Error: ${e instanceof Error ? e.message : e}`);
-    }
+      showToast('Reset'); await load();
+    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
-
   async function deleteItem(id: number) {
     if (!confirm('Delete this menu item?')) return;
     try {
       const res = await fetch(`${API_BASE}/menu/items/${id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error(`delete ${res.status}`);
-      showToast('Deleted');
-      await load();
-    } catch (e) {
-      showToast(`Error: ${e instanceof Error ? e.message : e}`);
-    }
+      showToast('Deleted'); await load();
+    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
+  }
+  async function addCustom() {
+    const path = prompt('Path (e.g. /my-link):'); if (!path) return;
+    const label = prompt('Label:', path.replace(/^\//, '').replace(/^./, (c) => c.toUpperCase())); if (!label) return;
+    try {
+      const res = await fetch(`${API_BASE}/menu/items`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ path, label, group: 'main', order: 999, source: 'custom', access: 'public' }) });
+      if (!res.ok) throw new Error(`create ${res.status}`);
+      showToast('Created'); await load();
+    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
 
-  async function addCustom() {
-    const path = prompt('Path (e.g. /my-link):');
-    if (!path) return;
-    const label = prompt('Label:', path.replace(/^\//, '').replace(/^./, (c) => c.toUpperCase()));
-    if (!label) return;
+  async function handleDragEnd(group: string, e: DragEndEvent) {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const groupItems = items.filter((i) => i.groupKey === group).sort((a, b) => a.position - b.position);
+    const oldIdx = groupItems.findIndex((i) => i.id === active.id);
+    const newIdx = groupItems.findIndex((i) => i.id === over.id);
+    if (oldIdx < 0 || newIdx < 0) return;
+    const reordered = arrayMove(groupItems, oldIdx, newIdx);
+    const payload = reordered.map((i, idx) => ({ id: i.id, parentId: i.parentId, position: (idx + 1) * 10 }));
+    setItems((prev) => prev.map((i) => {
+      const upd = payload.find((p) => p.id === i.id);
+      return upd ? { ...i, position: upd.position } : i;
+    }));
     try {
-      const res = await fetch(`${API_BASE}/menu/items`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ path, label, group: 'main', order: 999, source: 'custom', access: 'public' }),
-      });
-      if (!res.ok) throw new Error(`create ${res.status}`);
-      showToast('Created');
-      await load();
-    } catch (e) {
-      showToast(`Error: ${e instanceof Error ? e.message : e}`);
-    }
+      const res = await fetch(`${API_BASE}/menu/reorder`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ items: payload }) });
+      if (!res.ok) throw new Error(`reorder ${res.status}`);
+      showToast('Reordered'); await load();
+    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); await load(); }
   }
 
   const grouped: Record<string, MenuItem[]> = { main: [], tools: [], admin: [], hidden: [] };
-  for (const it of items) {
-    (grouped[it.groupKey] ?? (grouped[it.groupKey] = [])).push(it);
-  }
+  for (const it of items) (grouped[it.groupKey] ?? (grouped[it.groupKey] = [])).push(it);
   for (const g of GROUPS) grouped[g].sort((a, b) => a.position - b.position);
 
   return (
@@ -126,16 +200,9 @@ export function MenuEditor() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold">Menu Editor</h1>
-          <p className="text-sm text-text-secondary mt-1">
-            Edit the navbar. Routes seed defaults; your edits persist. {items.length} items.
-          </p>
+          <p className="text-sm text-text-secondary mt-1">Drag ⋮⋮ to reorder. Routes seed defaults; edits persist. {items.length} items.</p>
         </div>
-        <button
-          onClick={addCustom}
-          className="px-4 py-2 rounded-lg bg-accent/20 hover:bg-accent/30 text-accent border border-accent/40 text-sm font-medium"
-        >
-          + Add Custom Item
-        </button>
+        <button onClick={addCustom} className="px-4 py-2 rounded-lg bg-accent/20 hover:bg-accent/30 text-accent border border-accent/40 text-sm font-medium">+ Add Custom Item</button>
       </div>
 
       {loading && <div className="text-text-secondary">Loading…</div>}
@@ -147,84 +214,20 @@ export function MenuEditor() {
             <span className={`px-2 py-0.5 rounded text-xs border ${GROUP_COLORS[g]}`}>{g}</span>
             <span className="text-text-secondary text-sm">({grouped[g]?.length ?? 0})</span>
           </h2>
-          <div className="space-y-1">
-            {(grouped[g] ?? []).map((it) => (
-              <div
-                key={it.id}
-                className="flex items-center gap-3 px-3 py-2 rounded-lg bg-bg-elevated border border-border hover:border-accent/30 transition"
-              >
-                <input
-                  type="checkbox"
-                  checked={it.enabled}
-                  onChange={(e) => patchItem(it.id, { enabled: e.target.checked })}
-                  className="w-4 h-4"
-                  title="Enabled"
-                />
-                <span className="text-xs text-text-secondary font-mono w-12">#{it.position}</span>
-                <input
-                  type="text"
-                  defaultValue={it.label}
-                  onBlur={(e) => {
-                    if (e.target.value !== it.label) patchItem(it.id, { label: e.target.value });
-                  }}
-                  className="bg-transparent border-b border-transparent hover:border-border focus:border-accent focus:outline-none px-1 font-medium flex-none w-40"
-                />
-                <code className="text-xs text-text-secondary font-mono flex-1 truncate">{it.path}</code>
-                <span className={`px-2 py-0.5 rounded text-[10px] ${SOURCE_COLORS[it.source] ?? ''}`}>
-                  {it.source}
-                </span>
-                {it.touchedAt && (
-                  <span className="px-2 py-0.5 rounded text-[10px] bg-amber-500/10 text-amber-300 border border-amber-500/20">
-                    edited
-                  </span>
-                )}
-                <select
-                  value={it.groupKey}
-                  onChange={(e) => patchItem(it.id, { groupKey: e.target.value })}
-                  className="bg-bg-base border border-border rounded px-2 py-1 text-xs"
-                >
-                  {GROUPS.map((g) => <option key={g} value={g}>{g}</option>)}
-                </select>
-                <input
-                  type="number"
-                  defaultValue={it.position}
-                  onBlur={(e) => {
-                    const n = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(n) && n !== it.position) patchItem(it.id, { position: n });
-                  }}
-                  className="w-16 bg-bg-base border border-border rounded px-2 py-1 text-xs text-right"
-                  title="Order"
-                />
-                {it.touchedAt && it.source === 'route' && (
-                  <button
-                    onClick={() => resetItem(it.id)}
-                    className="text-xs text-text-secondary hover:text-accent"
-                    title="Reset to route default"
-                  >
-                    reset
-                  </button>
-                )}
-                <button
-                  onClick={() => deleteItem(it.id)}
-                  className="text-xs text-text-secondary hover:text-red-400"
-                  title="Delete"
-                >
-                  ✕
-                </button>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => handleDragEnd(g, e)}>
+            <SortableContext items={(grouped[g] ?? []).map((i) => i.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-1">
+                {(grouped[g] ?? []).map((it) => (
+                  <SortableRow key={it.id} item={it} onPatch={patchItem} onReset={resetItem} onDelete={deleteItem} />
+                ))}
+                {(grouped[g]?.length ?? 0) === 0 && <div className="text-sm text-text-secondary italic px-3 py-2">(empty)</div>}
               </div>
-            ))}
-            {(grouped[g]?.length ?? 0) === 0 && (
-              <div className="text-sm text-text-secondary italic px-3 py-2">(empty)</div>
-            )}
-          </div>
+            </SortableContext>
+          </DndContext>
         </section>
       ))}
 
-      {toast && (
-        <div className="fixed bottom-6 right-6 px-4 py-2 rounded-lg bg-bg-elevated border border-accent/40 shadow-lg text-sm">
-          {toast}
-        </div>
-      )}
+      {toast && <div className="fixed bottom-6 right-6 px-4 py-2 rounded-lg bg-bg-elevated border border-accent/40 shadow-lg text-sm">{toast}</div>}
     </div>
   );
 }


### PR DESCRIPTION
Adds dnd-kit drag-drop to /menu editor. Drag ⋮⋮ handle to reorder within a group. Calls POST /api/menu/reorder on drop, re-fetches after.