### PR TITLE
feat(planets): pure data layer — adapter + layout + nebulae + colors + orbits (part 1 of #36)

### DIFF
--- a/src/lib/planets/__tests__/adapter.test.ts
+++ b/src/lib/planets/__tests__/adapter.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'bun:test';
+import { buildPlanetsGraph } from '../adapter';
+import type { MapDocument as ApiMapDocument, OracleProject } from '../../../api/oracle';
+
+const NOW = Date.parse('2026-04-19T00:00:00Z');
+
+function proj(p: string, docs: number): OracleProject {
+  return { project: p, docs, types: 2, last_indexed: 0 };
+}
+
+function apiDoc(id: string, project: string, concepts: string[]): ApiMapDocument {
+  return {
+    id,
+    type: 'principle',
+    source_file: `${project}/${id}.md`,
+    concepts,
+    project,
+    x: Math.random() * 2 - 1,
+    y: Math.random() * 2 - 1,
+    z: Math.random() * 2 - 1,
+    created_at: '2026-04-15T00:00:00Z',
+  };
+}
+
+describe('buildPlanetsGraph', () => {
+  it('returns empty graph for no input', () => {
+    const g = buildPlanetsGraph([], [], undefined, NOW);
+    expect(g.documents.length).toBe(0);
+    expect(g.clusters.length).toBe(0);
+    expect(g.nebulae.length).toBe(0);
+  });
+
+  it('maps API docs → KM documents', () => {
+    const projects = [proj('repo/a', 2)];
+    const docs = [
+      apiDoc('d1', 'repo/a', ['x', 'y']),
+      apiDoc('d2', 'repo/a', ['y', 'z']),
+    ];
+    const g = buildPlanetsGraph(docs, projects, undefined, NOW);
+    expect(g.documents.length).toBe(2);
+    const d1 = g.documents.find((d) => d.id === 'd1')!;
+    expect(d1.sourceFile).toBe('repo/a/d1.md');
+    expect(d1.clusterId).toBe('repo/a');
+    expect(d1.createdAt).toBe(Date.parse('2026-04-15T00:00:00Z'));
+    expect(d1.parentId).toBeNull();
+    expect(d1.moonCount).toBe(0);
+    expect(d1.contentLength).toBeGreaterThan(0);
+  });
+
+  it('groups docs into one cluster per project', () => {
+    const projects = [proj('repo/a', 1), proj('repo/b', 1)];
+    const docs = [apiDoc('d1', 'repo/a', []), apiDoc('d2', 'repo/b', [])];
+    const g = buildPlanetsGraph(docs, projects, undefined, NOW);
+    expect(g.clusters.length).toBe(2);
+    const labels = g.clusters.map((c) => c.label).sort();
+    expect(labels).toEqual(['a', 'b']);
+  });
+
+  it('emits nebulae for projects that share ≥3 concepts', () => {
+    const projects = [proj('repo/a', 1), proj('repo/b', 1)];
+    const shared = ['p', 'q', 'r'];
+    const docs = [
+      apiDoc('d1', 'repo/a', shared),
+      apiDoc('d2', 'repo/b', shared),
+    ];
+    const g = buildPlanetsGraph(docs, projects, undefined, NOW);
+    expect(g.nebulae.length).toBe(1);
+    expect(new Set([g.nebulae[0].clusterA, g.nebulae[0].clusterB])).toEqual(
+      new Set(['repo/a', 'repo/b']),
+    );
+  });
+
+  it('puts orphan docs (project=null) in the Unsorted cluster', () => {
+    const docs: ApiMapDocument[] = [
+      { ...apiDoc('d1', 'anywhere', ['x']), project: null },
+    ];
+    const g = buildPlanetsGraph(docs, [], undefined, NOW);
+    expect(g.clusters.length).toBe(1);
+    expect(g.clusters[0].label).toBe('Unsorted');
+    expect(g.documents[0].clusterId).toBe('__unknown__');
+  });
+
+  it('snapshot structure: small 3-project / 6-doc fixture', () => {
+    const projects = [proj('repo/a', 2), proj('repo/b', 2), proj('repo/c', 2)];
+    const docs = [
+      apiDoc('a1', 'repo/a', ['ml', 'ai']),
+      apiDoc('a2', 'repo/a', ['ml', 'nlp']),
+      apiDoc('b1', 'repo/b', ['ml', 'ai', 'nlp']),
+      apiDoc('b2', 'repo/b', ['ml']),
+      apiDoc('c1', 'repo/c', ['biology']),
+      apiDoc('c2', 'repo/c', ['chemistry']),
+    ];
+    const g = buildPlanetsGraph(docs, projects, undefined, NOW);
+    expect(g.documents.length).toBe(6);
+    expect(g.clusters.length).toBe(3);
+    for (const d of g.documents) {
+      expect(Number.isFinite(d.orbitRadius)).toBe(true);
+      expect(Number.isFinite(d.orbitSpeed)).toBe(true);
+    }
+  });
+});

--- a/src/lib/planets/__tests__/colors.test.ts
+++ b/src/lib/planets/__tests__/colors.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  clusterColorFromTypes,
+  planetColor,
+  ageInDays,
+  TYPE_COLORS,
+} from '../colors';
+
+describe('clusterColorFromTypes', () => {
+  it('returns fallback grey for empty counts', () => {
+    expect(clusterColorFromTypes({})).toBe('#888888');
+  });
+
+  it('returns the palette color for a single type', () => {
+    expect(clusterColorFromTypes({ principle: 10 })).toBe(TYPE_COLORS.principle);
+    expect(clusterColorFromTypes({ learning: 3 })).toBe(TYPE_COLORS.learning);
+  });
+
+  it('mixes toward the heavier type', () => {
+    const mixed = clusterColorFromTypes({ principle: 10, retro: 1 });
+    expect(mixed).not.toBe(TYPE_COLORS.principle);
+    expect(mixed).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('ignores zero/negative counts', () => {
+    expect(clusterColorFromTypes({ principle: 0, learning: 0 })).toBe('#888888');
+  });
+});
+
+describe('planetColor', () => {
+  it('brightens recent (<7d) planets', () => {
+    const bright = planetColor('principle', 2);
+    expect(bright).not.toBe(TYPE_COLORS.principle);
+    expect(bright).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('keeps normal-age planets unchanged', () => {
+    expect(planetColor('learning', 20)).toBe(TYPE_COLORS.learning);
+  });
+
+  it('darkens old (>30d) planets', () => {
+    const faded = planetColor('retro', 90);
+    expect(faded).not.toBe(TYPE_COLORS.retro);
+  });
+
+  it('uses fallback for unknown type', () => {
+    expect(planetColor('mystery', 10)).toBe('#888888');
+  });
+});
+
+describe('ageInDays', () => {
+  it('returns Infinity for null', () => {
+    expect(ageInDays(null)).toBe(Infinity);
+  });
+
+  it('computes days since createdAt', () => {
+    const now = 1_700_000_000_000;
+    const oneDayAgo = now - 86_400_000;
+    expect(ageInDays(oneDayAgo, now)).toBeCloseTo(1, 5);
+  });
+
+  it('never returns negative age', () => {
+    const now = 1_700_000_000_000;
+    expect(ageInDays(now + 10_000, now)).toBe(0);
+  });
+});

--- a/src/lib/planets/__tests__/layout.test.ts
+++ b/src/lib/planets/__tests__/layout.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'bun:test';
+import { placeProjectsOnSphere, clusterRadiusFor } from '../layout';
+import type { OracleProject } from '../../../api/oracle';
+
+function proj(name: string, docs: number): OracleProject {
+  return { project: name, docs, types: 1, last_indexed: 0 };
+}
+
+describe('placeProjectsOnSphere', () => {
+  it('returns empty map for no projects', () => {
+    expect(placeProjectsOnSphere([]).size).toBe(0);
+  });
+
+  it('places a single project at origin', () => {
+    const m = placeProjectsOnSphere([proj('solo', 5)]);
+    const pos = m.get('solo');
+    expect(pos).toBeDefined();
+    expect(pos?.cx).toBe(0);
+    expect(pos?.cy).toBe(0);
+    expect(pos?.cz).toBe(0);
+  });
+
+  it('spreads 2 projects on opposite poles', () => {
+    const m = placeProjectsOnSphere([proj('a', 5), proj('b', 5)]);
+    const a = m.get('a')!;
+    const b = m.get('b')!;
+    expect(a.cy).toBeGreaterThan(0);
+    expect(b.cy).toBeLessThan(0);
+  });
+
+  it('gives every project a unique position for N=10', () => {
+    const projects = Array.from({ length: 10 }, (_, i) => proj(`p${i}`, 10));
+    const m = placeProjectsOnSphere(projects);
+    expect(m.size).toBe(10);
+    const positions = Array.from(m.values());
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const dx = positions[i].cx - positions[j].cx;
+        const dy = positions[i].cy - positions[j].cy;
+        const dz = positions[i].cz - positions[j].cz;
+        const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        expect(d).toBeGreaterThan(1);
+      }
+    }
+  });
+
+  it('cluster radius scales with docCount within bounds', () => {
+    expect(clusterRadiusFor(0)).toBeGreaterThanOrEqual(4);
+    expect(clusterRadiusFor(10_000)).toBeLessThanOrEqual(14);
+    expect(clusterRadiusFor(100)).toBeGreaterThan(clusterRadiusFor(5));
+  });
+
+  it('honors a custom radius option', () => {
+    const m = placeProjectsOnSphere(
+      [proj('a', 1), proj('b', 1)],
+      { radius: 50 },
+    );
+    const a = m.get('a')!;
+    const mag = Math.sqrt(a.cx * a.cx + a.cy * a.cy + a.cz * a.cz);
+    expect(mag).toBeGreaterThan(40);
+  });
+});

--- a/src/lib/planets/__tests__/nebulae.test.ts
+++ b/src/lib/planets/__tests__/nebulae.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test';
+import { buildNebulae, overlap } from '../nebulae';
+
+const center = (n: number) => ({ cx: n, cy: 0, cz: 0 });
+
+describe('overlap', () => {
+  it('computes Jaccard correctly', () => {
+    const a = new Set(['x', 'y', 'z']);
+    const b = new Set(['y', 'z', 'w']);
+    const { shared, jaccard } = overlap(a, b);
+    expect(shared).toBe(2);
+    expect(jaccard).toBeCloseTo(2 / 4, 5);
+  });
+
+  it('returns zero for disjoint sets', () => {
+    const { shared, jaccard } = overlap(new Set(['a']), new Set(['b']));
+    expect(shared).toBe(0);
+    expect(jaccard).toBe(0);
+  });
+
+  it('handles empty sets without dividing by zero', () => {
+    const { jaccard } = overlap(new Set(), new Set());
+    expect(jaccard).toBe(0);
+  });
+});
+
+describe('buildNebulae', () => {
+  it('emits nothing below the shared threshold', () => {
+    const concepts = new Map([
+      ['a', new Set(['x', 'y'])],
+      ['b', new Set(['y', 'z'])],
+    ]);
+    const centers = new Map([['a', center(0)], ['b', center(10)]]);
+    expect(buildNebulae(concepts, centers).length).toBe(0);
+  });
+
+  it('emits a nebula when ≥3 concepts are shared', () => {
+    const shared = new Set(['p', 'q', 'r', 's']);
+    const concepts = new Map([
+      ['a', new Set([...shared, 'unique-a'])],
+      ['b', new Set([...shared, 'unique-b'])],
+    ]);
+    const centers = new Map([['a', center(0)], ['b', center(10)]]);
+    const neb = buildNebulae(concepts, centers);
+    expect(neb.length).toBe(1);
+    expect(neb[0].cx).toBe(5);
+    expect(neb[0].strength).toBeGreaterThan(0);
+    expect(neb[0].color).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('is symmetric: A-B same as B-A regardless of input order', () => {
+    const A = new Set(['p', 'q', 'r']);
+    const B = new Set(['p', 'q', 'r', 's']);
+    const forward = buildNebulae(
+      new Map([['a', A], ['b', B]]),
+      new Map([['a', center(0)], ['b', center(10)]]),
+    );
+    const backward = buildNebulae(
+      new Map([['b', B], ['a', A]]),
+      new Map([['b', center(10)], ['a', center(0)]]),
+    );
+    expect(forward[0].strength).toBeCloseTo(backward[0].strength, 5);
+    expect(forward[0].cx).toBe(backward[0].cx);
+  });
+
+  it('skips pairs missing a cluster center', () => {
+    const concepts = new Map([
+      ['a', new Set(['p', 'q', 'r'])],
+      ['b', new Set(['p', 'q', 'r'])],
+    ]);
+    const centers = new Map([['a', center(0)]]);
+    expect(buildNebulae(concepts, centers).length).toBe(0);
+  });
+
+  it('honors a custom minShared option', () => {
+    const concepts = new Map([
+      ['a', new Set(['p', 'q'])],
+      ['b', new Set(['p', 'q'])],
+    ]);
+    const centers = new Map([['a', center(0)], ['b', center(10)]]);
+    expect(buildNebulae(concepts, centers, { minShared: 2 }).length).toBe(1);
+  });
+});

--- a/src/lib/planets/__tests__/orbits.test.ts
+++ b/src/lib/planets/__tests__/orbits.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'bun:test';
+import { computeOrbit, hashTilt, speedFromCreatedAt } from '../orbits';
+import type { MapDocument as ApiMapDocument } from '../../../api/oracle';
+
+function doc(partial: Partial<ApiMapDocument>): ApiMapDocument {
+  return {
+    id: 'd1',
+    type: 'principle',
+    source_file: 'a.md',
+    concepts: [],
+    project: 'p',
+    x: 1,
+    y: 0,
+    z: 0,
+    created_at: null,
+    ...partial,
+  };
+}
+
+const center = { cx: 10, cy: 0, cz: 0, radius: 8 };
+
+describe('computeOrbit', () => {
+  it('produces phase from atan2(y, x)', () => {
+    const r = computeOrbit(doc({ x: 0, y: 1, z: 0 }), center, 0);
+    expect(r.orbitPhase).toBeCloseTo(Math.PI / 2, 5);
+  });
+
+  it('is symmetric: opposite points yield opposite phase sign', () => {
+    const a = computeOrbit(doc({ id: 'A', x: 1, y: 1, z: 0 }), center, 0);
+    const b = computeOrbit(doc({ id: 'B', x: -1, y: -1, z: 0 }), center, 0);
+    expect(Math.sign(a.orbitPhase)).toBe(-Math.sign(b.orbitPhase));
+  });
+
+  it('deterministic tilt per id', () => {
+    const a = computeOrbit(doc({ id: 'same' }), center, 0);
+    const b = computeOrbit(doc({ id: 'same' }), center, 99);
+    expect(a.orbitTilt).toBe(b.orbitTilt);
+  });
+
+  it('tilt stays within [0, 0.3]', () => {
+    for (const k of ['a', 'foo', 'longer-key', '', 'αβγ']) {
+      const t = hashTilt(k);
+      expect(t).toBeGreaterThanOrEqual(0);
+      expect(t).toBeLessThanOrEqual(0.3);
+    }
+  });
+
+  it('places the doc around its cluster center', () => {
+    const r = computeOrbit(doc({ x: 1, y: 0, z: 0 }), center, 0);
+    const dist = Math.hypot(r.x - center.cx, r.y - center.cy, r.z - center.cz);
+    expect(dist).toBeCloseTo(r.orbitRadius, 5);
+  });
+});
+
+describe('speedFromCreatedAt', () => {
+  const NOW = Date.parse('2026-04-19T00:00:00Z');
+
+  it('returns fast speed for docs <7d', () => {
+    expect(speedFromCreatedAt('2026-04-17T00:00:00Z', NOW)).toBe(0.003);
+  });
+
+  it('returns medium speed for 7-30d docs', () => {
+    expect(speedFromCreatedAt('2026-04-01T00:00:00Z', NOW)).toBe(0.002);
+  });
+
+  it('returns slow speed for >30d docs', () => {
+    expect(speedFromCreatedAt('2026-01-01T00:00:00Z', NOW)).toBe(0.001);
+  });
+
+  it('defaults to slow for missing/bad timestamps', () => {
+    expect(speedFromCreatedAt(null, NOW)).toBe(0.001);
+    expect(speedFromCreatedAt('not-a-date', NOW)).toBe(0.001);
+  });
+});

--- a/src/lib/planets/adapter.ts
+++ b/src/lib/planets/adapter.ts
@@ -1,0 +1,125 @@
+// Orchestrator: Oracle API shape → knowledge-map-3d graph.
+
+import type {
+  MapDocument as KMDocument,
+  ClusterMeta,
+  NebulaMeta,
+} from 'knowledge-map-3d';
+import type {
+  MapDocument as ApiMapDocument,
+  OracleProject,
+  Stats,
+} from '../../api/oracle';
+import { placeProjectsOnSphere, type ClusterPosition } from './layout';
+import { computeOrbit } from './orbits';
+import { buildNebulae } from './nebulae';
+
+export interface PlanetsGraph {
+  documents: KMDocument[];
+  clusters: ClusterMeta[];
+  nebulae: NebulaMeta[];
+}
+
+const UNKNOWN_CLUSTER = '__unknown__';
+
+export function buildPlanetsGraph(
+  apiDocs: ApiMapDocument[],
+  projects: OracleProject[],
+  _stats?: Stats,
+  now: number = Date.now(),
+): PlanetsGraph {
+  const centers = placeProjectsOnSphere(projects);
+  const docsByProject = groupDocsByProject(apiDocs);
+
+  if (docsByProject.has(UNKNOWN_CLUSTER) && !centers.has(UNKNOWN_CLUSTER)) {
+    centers.set(UNKNOWN_CLUSTER, { cx: 0, cy: 0, cz: 0, radius: 6 });
+  }
+
+  const documents: KMDocument[] = [];
+  const clusters: ClusterMeta[] = [];
+  const projectConcepts = new Map<string, Set<string>>();
+
+  for (const [projectId, center] of centers.entries()) {
+    const docs = docsByProject.get(projectId) ?? [];
+    const concepts = new Set<string>();
+
+    docs.forEach((d, i) => {
+      const orbit = computeOrbit(d, center, i, now);
+      const createdAtMs = parseUnixMs(d.created_at);
+      for (const c of d.concepts ?? []) concepts.add(c);
+      documents.push({
+        id: d.id,
+        type: d.type,
+        sourceFile: d.source_file,
+        concepts: d.concepts ?? [],
+        chunkIds: d.chunk_ids,
+        project: d.project ?? null,
+        x: orbit.x,
+        y: orbit.y,
+        z: orbit.z,
+        clusterId: projectId,
+        orbitRadius: orbit.orbitRadius,
+        orbitSpeed: orbit.orbitSpeed,
+        orbitPhase: orbit.orbitPhase,
+        orbitTilt: orbit.orbitTilt,
+        parentId: null,
+        moonCount: 0,
+        createdAt: createdAtMs,
+        contentLength: estimateContentLength(d),
+      });
+    });
+
+    projectConcepts.set(projectId, concepts);
+
+    clusters.push({
+      id: projectId,
+      label: clusterLabel(projectId),
+      docCount: docs.length,
+      cx: center.cx,
+      cy: center.cy,
+      cz: center.cz,
+      radius: center.radius,
+      concepts: Array.from(concepts).slice(0, 8),
+      starDocId: docs[0]?.id ?? null,
+    });
+  }
+
+  const centerLite = new Map<string, { cx: number; cy: number; cz: number }>();
+  for (const [k, v] of centers.entries()) {
+    centerLite.set(k, { cx: v.cx, cy: v.cy, cz: v.cz });
+  }
+  const nebulae = buildNebulae(projectConcepts, centerLite);
+
+  return { documents, clusters, nebulae };
+}
+
+function groupDocsByProject(apiDocs: ApiMapDocument[]): Map<string, ApiMapDocument[]> {
+  const out = new Map<string, ApiMapDocument[]>();
+  for (const d of apiDocs) {
+    const key = d.project ?? UNKNOWN_CLUSTER;
+    const arr = out.get(key) ?? [];
+    arr.push(d);
+    out.set(key, arr);
+  }
+  return out;
+}
+
+function parseUnixMs(s: string | null | undefined): number | null {
+  if (!s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+function estimateContentLength(d: ApiMapDocument): number {
+  const conceptsLen = (d.concepts ?? []).join(' ').length;
+  const pathLen = (d.source_file ?? '').length;
+  return 500 + conceptsLen * 20 + pathLen * 4;
+}
+
+function clusterLabel(project: string): string {
+  if (project === UNKNOWN_CLUSTER) return 'Unsorted';
+  const parts = project.split('/');
+  return parts[parts.length - 1] || project;
+}
+
+export type { ClusterPosition };

--- a/src/lib/planets/colors.ts
+++ b/src/lib/planets/colors.ts
@@ -1,0 +1,69 @@
+// Type → hex palette + age lightness modifier. Pure data-only.
+
+export const TYPE_COLORS: Record<string, string> = {
+  principle: '#60a5fa',
+  learning: '#a78bfa',
+  retro: '#fbbf24',
+  unknown: '#888888',
+};
+
+const FALLBACK = '#888888';
+
+export function clusterColorFromTypes(counts: Record<string, number>): string {
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let total = 0;
+  for (const [type, n] of Object.entries(counts)) {
+    if (!n || n <= 0) continue;
+    const [cr, cg, cb] = hexToRgb(TYPE_COLORS[type] ?? FALLBACK);
+    r += cr * n;
+    g += cg * n;
+    b += cb * n;
+    total += n;
+  }
+  if (total === 0) return FALLBACK;
+  return rgbToHex(Math.round(r / total), Math.round(g / total), Math.round(b / total));
+}
+
+export function planetColor(type: string, ageDays: number): string {
+  const base = TYPE_COLORS[type] ?? FALLBACK;
+  let shift = 0;
+  if (ageDays < 7) shift = 0.2;
+  else if (ageDays > 30) shift = -0.2;
+  return shiftLightness(base, shift);
+}
+
+export function ageInDays(createdAt: number | null | undefined, now: number = Date.now()): number {
+  if (createdAt == null) return Infinity;
+  return Math.max(0, (now - createdAt) / 86_400_000);
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const clean = hex.replace('#', '');
+  const full = clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return '#' + [r, g, b].map((v) => clamp(v, 0, 255).toString(16).padStart(2, '0')).join('');
+}
+
+function shiftLightness(hex: string, delta: number): string {
+  const [r, g, b] = hexToRgb(hex);
+  if (delta === 0) return hex;
+  if (delta > 0) {
+    return rgbToHex(
+      Math.round(r + (255 - r) * delta),
+      Math.round(g + (255 - g) * delta),
+      Math.round(b + (255 - b) * delta),
+    );
+  }
+  const f = 1 + delta;
+  return rgbToHex(Math.round(r * f), Math.round(g * f), Math.round(b * f));
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}

--- a/src/lib/planets/index.ts
+++ b/src/lib/planets/index.ts
@@ -1,0 +1,5 @@
+export * from './colors';
+export * from './layout';
+export * from './orbits';
+export * from './nebulae';
+export * from './adapter';

--- a/src/lib/planets/layout.ts
+++ b/src/lib/planets/layout.ts
@@ -1,0 +1,60 @@
+// Fibonacci-sphere placement for N projects (clusters).
+
+import type { OracleProject } from '../../api/oracle';
+
+export interface ClusterPosition {
+  cx: number;
+  cy: number;
+  cz: number;
+  radius: number;
+}
+
+export interface LayoutOptions {
+  radius?: number;
+  minClusterRadius?: number;
+  maxClusterRadius?: number;
+}
+
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+export function placeProjectsOnSphere(
+  projects: OracleProject[],
+  options: LayoutOptions = {},
+): Map<string, ClusterPosition> {
+  const out = new Map<string, ClusterPosition>();
+  const N = projects.length;
+  if (N === 0) return out;
+
+  const totalDocs = projects.reduce((s, p) => s + (p.docs ?? 0), 0);
+  const sphereRadius = options.radius ?? Math.max(12, 6 * Math.log2(Math.max(2, totalDocs)));
+  const minR = options.minClusterRadius ?? 4;
+  const maxR = options.maxClusterRadius ?? 14;
+
+  if (N === 1) {
+    const p = projects[0];
+    out.set(p.project, { cx: 0, cy: 0, cz: 0, radius: clusterRadiusFor(p.docs ?? 0, minR, maxR) });
+    return out;
+  }
+
+  for (let i = 0; i < N; i++) {
+    const y = 1 - (2 * i) / (N - 1);
+    const rRing = Math.sqrt(Math.max(0, 1 - y * y));
+    const theta = GOLDEN_ANGLE * i;
+    const cx = Math.cos(theta) * rRing * sphereRadius;
+    const cy = y * sphereRadius;
+    const cz = Math.sin(theta) * rRing * sphereRadius;
+    const p = projects[i];
+    out.set(p.project, {
+      cx,
+      cy,
+      cz,
+      radius: clusterRadiusFor(p.docs ?? 0, minR, maxR),
+    });
+  }
+  return out;
+}
+
+export function clusterRadiusFor(docCount: number, minR = 4, maxR = 14): number {
+  const scaled = Math.log2(Math.max(2, docCount + 1)) * 2;
+  return Math.min(maxR, Math.max(minR, scaled));
+}

--- a/src/lib/planets/nebulae.ts
+++ b/src/lib/planets/nebulae.ts
@@ -1,0 +1,82 @@
+// Pairwise concept-overlap nebulae between clusters.
+
+import type { NebulaMeta } from 'knowledge-map-3d';
+
+export interface ClusterCenterLite {
+  cx: number;
+  cy: number;
+  cz: number;
+}
+
+export interface NebulaOptions {
+  minShared?: number;
+}
+
+export function buildNebulae(
+  projectConcepts: Map<string, Set<string>>,
+  clusterCenters: Map<string, ClusterCenterLite>,
+  options: NebulaOptions = {},
+): NebulaMeta[] {
+  const minShared = options.minShared ?? 3;
+  const keys = Array.from(projectConcepts.keys())
+    .filter((k) => clusterCenters.has(k))
+    .sort();
+
+  const out: NebulaMeta[] = [];
+  for (let i = 0; i < keys.length; i++) {
+    for (let j = i + 1; j < keys.length; j++) {
+      const a = keys[i];
+      const b = keys[j];
+      const A = projectConcepts.get(a);
+      const B = projectConcepts.get(b);
+      if (!A || !B) continue;
+      const { shared, jaccard } = overlap(A, B);
+      if (shared < minShared) continue;
+      const ca = clusterCenters.get(a);
+      const cb = clusterCenters.get(b);
+      if (!ca || !cb) continue;
+      out.push({
+        id: `neb-${a}-${b}`,
+        clusterA: a,
+        clusterB: b,
+        cx: (ca.cx + cb.cx) / 2,
+        cy: (ca.cy + cb.cy) / 2,
+        cz: (ca.cz + cb.cz) / 2,
+        strength: jaccard,
+        color: conceptHueColor(sharedConcepts(A, B)),
+      });
+    }
+  }
+  return out;
+}
+
+export function overlap(a: Set<string>, b: Set<string>): { shared: number; jaccard: number } {
+  let shared = 0;
+  for (const v of a) if (b.has(v)) shared++;
+  const union = a.size + b.size - shared;
+  return { shared, jaccard: union === 0 ? 0 : shared / union };
+}
+
+function sharedConcepts(a: Set<string>, b: Set<string>): string[] {
+  const out: string[] = [];
+  for (const v of a) if (b.has(v)) out.push(v);
+  return out.sort();
+}
+
+function conceptHueColor(concepts: string[]): string {
+  let h = 0;
+  for (const c of concepts) {
+    for (let i = 0; i < c.length; i++) h = (h + c.charCodeAt(i)) % 360;
+  }
+  return hslToHex(h, 70, 60);
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = sN * Math.min(lN, 1 - lN);
+  const f = (n: number) => lN - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  const toHex = (v: number) => Math.round(v * 255).toString(16).padStart(2, '0');
+  return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
+}

--- a/src/lib/planets/orbits.ts
+++ b/src/lib/planets/orbits.ts
@@ -1,0 +1,69 @@
+// Per-doc orbit parameters relative to its cluster center.
+
+import type { MapDocument as ApiMapDocument } from '../../api/oracle';
+
+export interface OrbitResult {
+  orbitRadius: number;
+  orbitSpeed: number;
+  orbitPhase: number;
+  orbitTilt: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface ClusterCenter {
+  cx: number;
+  cy: number;
+  cz: number;
+  radius?: number;
+}
+
+export function computeOrbit(
+  doc: ApiMapDocument,
+  center: ClusterCenter,
+  docIndex: number,
+  now: number = Date.now(),
+): OrbitResult {
+  const dx = doc.x ?? 0;
+  const dy = doc.y ?? 0;
+  const dz = doc.z ?? 0;
+
+  const rawR = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+  const clusterR = center.radius ?? 8;
+  const orbitRadius = clusterR * 0.3 + (rawR % clusterR);
+
+  const orbitPhase = Math.atan2(dy, dx);
+  const orbitTilt = hashTilt(doc.id ?? String(docIndex));
+  const orbitSpeed = speedFromCreatedAt(doc.created_at, now);
+
+  const x = center.cx + Math.cos(orbitPhase) * orbitRadius;
+  const y = center.cy + Math.sin(orbitPhase) * orbitRadius * Math.cos(orbitTilt);
+  const z = center.cz + Math.sin(orbitPhase) * orbitRadius * Math.sin(orbitTilt);
+
+  return { orbitRadius, orbitSpeed, orbitPhase, orbitTilt, x, y, z };
+}
+
+export function speedFromCreatedAt(
+  createdAt: string | null | undefined,
+  now: number = Date.now(),
+): number {
+  if (!createdAt) return 0.001;
+  const t = Date.parse(createdAt);
+  if (!Number.isFinite(t)) return 0.001;
+  const ageDays = (now - t) / 86_400_000;
+  if (ageDays < 7) return 0.003;
+  if (ageDays < 30) return 0.002;
+  return 0.001;
+}
+
+/** Deterministic hash → tilt in [0, 0.3] rad. FNV-1a. */
+export function hashTilt(key: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const normalized = (h >>> 0) / 0xffffffff;
+  return normalized * 0.3;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

Part 1 of #36 — pure data-transformation layer that turns Oracle API shapes into a `knowledge-map-3d` graph (documents + clusters + nebulae). No fetch, no React, no Three.js.

## Modules (all ≤200 lines)

- `src/lib/planets/colors.ts` — 69 LOC — type→hex palette + age lightness shift
- `src/lib/planets/layout.ts` — 60 LOC — fibonacci-sphere cluster placement
- `src/lib/planets/orbits.ts` — 69 LOC — per-doc orbit params (radius / speed / phase / tilt)
- `src/lib/planets/nebulae.ts` — 82 LOC — Jaccard concept-overlap → `NebulaMeta[]`
- `src/lib/planets/adapter.ts` — 125 LOC — `buildPlanetsGraph(apiDocs, projects, stats?)` orchestrator
- `src/lib/planets/index.ts` — 5 LOC — barrel export

## Tests

`src/lib/planets/__tests__/*.test.ts` — 5 files, **40 tests / 135 expect() calls**, run via `bun test`. Covers:

- colors: empty / single / mixed type counts; age-band color shifts
- layout: N=1, N=2, N=10 unique positions; radius bounds; custom radius
- orbits: atan2 phase, deterministic tilt, tilt ∈ [0, 0.3], speed bands
- nebulae: Jaccard, threshold, A-B == B-A symmetry, missing centers
- adapter: structure snapshot with 3-project / 6-doc fixture, orphan `project=null` → Unsorted cluster

## Verification

- `bunx tsc -b` → exit 0 (tests excluded via `tsconfig.app.json` — `bun:test` types not installed)
- `bun test src/lib/planets/__tests__/` → 40 pass, 0 fail

## Downstream (issue #36)

Navigator (hooks) and painter (components) tasks consume `buildPlanetsGraph` via the barrel export.

Part 1 of #36.

🤖 ตอบโดย arra-oracle-v3 (cartographer agent) จาก Nat → arra-oracle-v3-oracle