### PR TITLE
feat(planets): data hooks — usePlanetsData + usePlanetsSearch (part 2 of #36)

### DIFF
--- a/src/hooks/usePlanetsData.ts
+++ b/src/hooks/usePlanetsData.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ClusterMeta, MapDocument, NebulaMeta } from 'knowledge-map-3d';
+import {
+  getMap,
+  getMap3d,
+  getOracles,
+  getStats,
+} from '../api/oracle';
+import type { MapDocument as ApiMapDocument, Stats } from '../api/oracle';
+import { buildPlanetsGraph } from '../lib/planets';
+
+export interface UsePlanetsData {
+  documents: MapDocument[];
+  clusters: ClusterMeta[];
+  nebulae: NebulaMeta[];
+  stats: Stats | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+  model: string | undefined;
+  setModel: (m: string | undefined) => void;
+}
+
+const EMPTY_ORACLES = {
+  projects: [],
+  identities: [],
+  total_projects: 0,
+  total_identities: 0,
+};
+
+export function usePlanetsData(initialModel?: string): UsePlanetsData {
+  const [documents, setDocuments] = useState<MapDocument[]>([]);
+  const [clusters, setClusters] = useState<ClusterMeta[]>([]);
+  const [nebulae, setNebulae] = useState<NebulaMeta[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [model, setModel] = useState<string | undefined>(initialModel);
+  const [tick, setTick] = useState(0);
+  const reqId = useRef(0);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+
+  useEffect(() => {
+    const id = ++reqId.current;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        let apiDocs: ApiMapDocument[];
+        try {
+          const map = await getMap3d(model);
+          apiDocs = map.documents ?? [];
+        } catch {
+          const map2d = await getMap();
+          apiDocs = (map2d.documents ?? []).map((d) => ({ ...d, z: 0 }));
+        }
+
+        const [oracles, statsResp] = await Promise.all([
+          getOracles().catch(() => EMPTY_ORACLES),
+          getStats().catch<Stats | null>(() => null),
+        ]);
+
+        if (id !== reqId.current) return;
+
+        const graph = buildPlanetsGraph(
+          apiDocs,
+          oracles.projects,
+          statsResp ?? undefined,
+        );
+        setDocuments(graph.documents);
+        setClusters(graph.clusters);
+        setNebulae(graph.nebulae);
+        setStats(statsResp);
+        setLoading(false);
+      } catch (e) {
+        if (id !== reqId.current) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      }
+    })();
+  }, [model, tick]);
+
+  return {
+    documents,
+    clusters,
+    nebulae,
+    stats,
+    loading,
+    error,
+    reload,
+    model,
+    setModel,
+  };
+}

--- a/src/hooks/usePlanetsSearch.ts
+++ b/src/hooks/usePlanetsSearch.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { search } from '../api/oracle';
+import type { Document } from '../api/oracle';
+
+export interface UsePlanetsSearch {
+  query: string;
+  setQuery: (q: string) => void;
+  matchIds: Set<string>;
+  matching: Document[];
+  error: string | null;
+  clear: () => void;
+}
+
+export function usePlanetsSearch(debounceMs: number = 300): UsePlanetsSearch {
+  const [query, setQueryState] = useState('');
+  const [matching, setMatching] = useState<Document[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setMatching([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await search(q, 'all', 50, 'hybrid');
+        if (cancelled) return;
+        setMatching(res.results ?? []);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setMatching([]);
+      }
+    }, debounceMs);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query, debounceMs]);
+
+  const matchIds = useMemo(
+    () => new Set(matching.map((d) => d.id)),
+    [matching],
+  );
+
+  const setQuery = useCallback((q: string) => setQueryState(q), []);
+  const clear = useCallback(() => setQueryState(''), []);
+
+  return { query, setQuery, matchIds, matching, error, clear };
+}


### PR DESCRIPTION
## Summary
- `usePlanetsData` — fetches `/map3d` + `/oracles` + `/stats`, runs `buildPlanetsGraph` from `src/lib/planets`. Falls back to `/map` (2D, z=0) when `/map3d` fails. Exposes `{documents, clusters, nebulae, stats, loading, error, reload, model, setModel}`.
- `usePlanetsSearch` — 300ms-debounced hybrid search via `search(q, 'all', 50, 'hybrid')`. Returns `matchIds: Set<string>` for O(1) highlight lookup, `matching[]` for list rendering, plus `{query, setQuery, clear, error}`.

Pure hooks — no Three.js, no components. Consumed by the painter step (#3).

LOC: `usePlanetsData.ts` 96 · `usePlanetsSearch.ts` 56. Both well under the ≤180/≤120 budget.

Built on #37 (cartographer's pure data layer).

## Test plan
- [ ] `bunx tsc -b` clean ✅
- [ ] Painter wires hooks into Planets.tsx
- [ ] Prover runs dev-browser smoke against a live Oracle API

🤖 Generated with [Claude Code](https://claude.com/claude-code)