### PR TITLE
feat(planets): UI components + thin page orchestrator (part 3, closes #36)

### DIFF
--- a/src/components/planets/EngineList.tsx
+++ b/src/components/planets/EngineList.tsx
@@ -1,0 +1,66 @@
+import type { Stats } from '../../api/oracle';
+
+type Engine = NonNullable<Stats['vectors']>[number];
+
+interface Props {
+  engines: Engine[];
+  model: string | undefined;
+  onSetModel: (m: string | undefined) => void;
+}
+
+export function EngineList({ engines, model, onSetModel }: Props) {
+  if (engines.length === 0) return null;
+  const activeKey = model ?? 'bge-m3';
+
+  return (
+    <>
+      <div className="h-px bg-border my-1" />
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-mono uppercase tracking-wide text-text-muted">
+          Embedding Engines
+        </span>
+        <span className="text-[9px] font-mono text-text-muted">LanceDB</span>
+      </div>
+      {engines.map((v) => {
+        const active = activeKey === v.key;
+        return (
+          <button
+            key={v.key}
+            onClick={() => v.enabled && onSetModel(v.key)}
+            disabled={!v.enabled}
+            className={`flex flex-col gap-0.5 p-2 rounded-lg border text-left transition-all duration-150 ${
+              active
+                ? 'border-accent/40 bg-accent/5'
+                : v.enabled
+                ? 'border-border bg-white/[0.02] hover:border-border-hover cursor-pointer'
+                : 'border-border-subtle opacity-50 cursor-not-allowed'
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-text-primary">
+                {v.key}
+              </span>
+              <span
+                className={`text-[9px] font-mono font-semibold uppercase px-1.5 py-0.5 rounded ${
+                  active
+                    ? 'bg-accent/20 text-accent'
+                    : v.enabled
+                    ? 'bg-success/20 text-success'
+                    : 'bg-red-500/20 text-red-400'
+                }`}
+              >
+                {active ? 'Active' : v.enabled ? 'Switch' : 'Offline'}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-muted font-mono">{v.model}</span>
+              <span className="text-[9px] text-text-muted tabular-nums">
+                {v.count.toLocaleString()}
+              </span>
+            </div>
+          </button>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/planets/NebulaLegend.tsx
+++ b/src/components/planets/NebulaLegend.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'planets.legend.dismissed';
+const OVERLAY_BG = 'rgba(10, 10, 20, 0.75)';
+
+export function NebulaLegend() {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    try {
+      setDismissed(localStorage.getItem(STORAGE_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {}
+    setDismissed(true);
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      className="absolute bottom-4 right-4 max-w-[260px] rounded-[10px] px-3.5 py-3 text-[11px] text-text-secondary backdrop-blur-xl border border-white/[0.08] z-10 leading-relaxed"
+      style={{ background: OVERLAY_BG }}
+    >
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <span className="text-xs font-semibold text-text-primary">
+          Nebula Legend
+        </span>
+        <button
+          onClick={dismiss}
+          className="text-text-muted hover:text-accent cursor-pointer text-xs leading-none"
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      </div>
+      <p>
+        Colored clouds connect projects that share concepts. Brighter = stronger
+        overlap. Click a planet to open its document.
+      </p>
+    </div>
+  );
+}

--- a/src/components/planets/PlanetsCanvas.tsx
+++ b/src/components/planets/PlanetsCanvas.tsx
@@ -1,0 +1,36 @@
+import { KnowledgeMap } from 'knowledge-map-3d';
+import type { MapDocument, ClusterMeta, NebulaMeta } from 'knowledge-map-3d';
+import { TYPE_COLORS } from '../../lib/type-colors';
+
+interface Props {
+  documents: MapDocument[];
+  clusters: ClusterMeta[];
+  nebulae: NebulaMeta[];
+  highlightIds: Set<string>;
+  onDocumentClick: (doc: MapDocument) => void;
+  onClusterClick?: (cluster: ClusterMeta) => void;
+}
+
+export function PlanetsCanvas({
+  documents,
+  clusters,
+  nebulae,
+  highlightIds,
+  onDocumentClick,
+  onClusterClick,
+}: Props) {
+  return (
+    <KnowledgeMap
+      documents={documents}
+      clusters={clusters}
+      nebulae={nebulae}
+      highlightIds={highlightIds}
+      onDocumentClick={onDocumentClick}
+      onClusterClick={onClusterClick}
+      typeColors={TYPE_COLORS}
+      embedded
+      heightMode="auto"
+      className="w-full h-full"
+    />
+  );
+}

--- a/src/components/planets/PlanetsEmpty.tsx
+++ b/src/components/planets/PlanetsEmpty.tsx
@@ -1,0 +1,40 @@
+export function PlanetsLoading() {
+  return (
+    <div className="flex flex-col items-center justify-center h-[calc(100vh-64px)] gap-3 bg-black">
+      <div className="text-lg text-text-primary">Loading planets...</div>
+      <div className="text-[13px] text-text-muted">
+        Fetching embeddings and building the universe...
+      </div>
+    </div>
+  );
+}
+
+interface EmptyProps {
+  message?: string;
+}
+
+export function PlanetsEmpty({ message }: EmptyProps) {
+  const hasError = Boolean(message);
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-[calc(100vh-64px)] gap-3 bg-black text-center px-6"
+    >
+      <div
+        className={`text-[22px] font-bold ${hasError ? 'text-[#ef4444]' : 'text-text-primary'}`}
+      >
+        {hasError ? 'Failed to load planets' : 'No Planets Yet'}
+      </div>
+      <div className="text-sm text-text-muted leading-relaxed max-w-md">
+        {hasError ? (
+          message
+        ) : (
+          <>
+            The planets universe needs vector embeddings from LanceDB.
+            <br />
+            Run a vector index to populate the map.
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/planets/PlanetsHUD.tsx
+++ b/src/components/planets/PlanetsHUD.tsx
@@ -1,0 +1,85 @@
+import { TYPE_COLORS } from '../../lib/type-colors';
+
+interface Props {
+  query: string;
+  onQueryChange: (q: string) => void;
+  onClear: () => void;
+  searching?: boolean;
+  matchCount: number;
+  visibleTypes: Set<string>;
+  onToggleType: (type: string) => void;
+}
+
+const OVERLAY_BG = 'rgba(10, 10, 20, 0.7)';
+
+export function PlanetsHUD({
+  query,
+  onQueryChange,
+  onClear,
+  searching = false,
+  matchCount,
+  visibleTypes,
+  onToggleType,
+}: Props) {
+  return (
+    <>
+      <form
+        onSubmit={(e) => e.preventDefault()}
+        className="absolute top-4 left-1/2 -translate-x-1/2 flex gap-2 z-10 items-center"
+      >
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Search to highlight planets..."
+          className="w-[320px] px-4 py-2.5 rounded-[10px] text-sm text-text-primary border border-white/[0.08] outline-none backdrop-blur-xl transition-colors duration-200 focus:border-accent placeholder:text-text-muted [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
+          style={{ background: OVERLAY_BG, WebkitAppearance: 'none' }}
+        />
+        {query && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="px-3.5 py-2 rounded-[10px] text-xs text-text-secondary cursor-pointer border border-white/[0.08] backdrop-blur-xl transition-all duration-200 hover:border-accent hover:text-accent"
+            style={{ background: OVERLAY_BG }}
+          >
+            Clear
+          </button>
+        )}
+        {searching && (
+          <span className="w-2 h-2 rounded-full bg-accent animate-pulse" />
+        )}
+        {query && matchCount > 0 && (
+          <span
+            className="text-[11px] font-mono text-text-muted px-2 py-1 rounded-md backdrop-blur-xl border border-white/[0.08]"
+            style={{ background: OVERLAY_BG }}
+          >
+            {matchCount} match{matchCount === 1 ? '' : 'es'}
+          </span>
+        )}
+      </form>
+
+      <div
+        className="absolute bottom-4 left-4 flex gap-1 rounded-[10px] px-2 py-1.5 text-[11px] text-text-secondary backdrop-blur-xl border border-white/[0.08] z-10"
+        style={{ background: OVERLAY_BG }}
+      >
+        {Object.entries(TYPE_COLORS).map(([type, color]) => {
+          const active = visibleTypes.has(type);
+          return (
+            <button
+              key={type}
+              onClick={() => onToggleType(type)}
+              className={`flex items-center gap-[5px] px-2 py-1 rounded-md cursor-pointer border-none transition-all duration-150 ${active ? 'opacity-100' : 'opacity-30'}`}
+              style={{ background: active ? `${color}15` : 'transparent' }}
+            >
+              <span
+                className="w-[7px] h-[7px] rounded-full"
+                style={{ background: color }}
+              />
+              {type}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/planets/PlanetsSidebar.tsx
+++ b/src/components/planets/PlanetsSidebar.tsx
@@ -1,0 +1,153 @@
+import type { ClusterMeta } from 'knowledge-map-3d';
+import type { Stats } from '../../api/oracle';
+import { TYPE_COLORS } from '../../lib/type-colors';
+import { EngineList } from './EngineList';
+
+interface Props {
+  stats: Stats | null;
+  clusters: ClusterMeta[];
+  totalDocs: number;
+  typeCounts: Record<string, number>;
+  matchCount: number;
+  selectedProject: string | null;
+  onSelectProject: (project: string | null) => void;
+  model: string | undefined;
+  onSetModel: (m: string | undefined) => void;
+}
+
+export function PlanetsSidebar({
+  stats,
+  clusters,
+  totalDocs,
+  typeCounts,
+  matchCount,
+  selectedProject,
+  onSelectProject,
+  model,
+  onSetModel,
+}: Props) {
+  const sorted = [...clusters].sort((a, b) => b.docCount - a.docCount);
+
+  return (
+    <div className="w-[260px] bg-bg-card border-l border-border p-6 flex flex-col overflow-hidden">
+      <h2 className="text-xl font-bold text-text-primary mb-1">Planets</h2>
+      <span className="text-[11px] font-mono text-text-muted mb-4 block">
+        {clusters.length} cluster{clusters.length === 1 ? '' : 's'} active
+      </span>
+
+      <div className="flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto">
+        {stats?.total != null && (
+          <Stat value={stats.total} label="Total Indexed" />
+        )}
+        <Stat value={totalDocs} label="Documents Mapped" />
+
+        {Object.entries(typeCounts).map(([type, count]) => (
+          <Stat
+            key={type}
+            value={count}
+            label={`${type}s`}
+            color={TYPE_COLORS[type]}
+          />
+        ))}
+
+        <EngineList
+          engines={stats?.vectors ?? []}
+          model={model}
+          onSetModel={onSetModel}
+        />
+
+        {sorted.length > 0 && (
+          <ProjectList
+            clusters={sorted}
+            selectedProject={selectedProject}
+            onSelectProject={onSelectProject}
+          />
+        )}
+
+        {matchCount > 0 && (
+          <>
+            <div className="h-px bg-border my-1" />
+            <Stat value={matchCount} label="Search Matches" color="#4ade80" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  value,
+  label,
+  color,
+}: {
+  value: number;
+  label: string;
+  color?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span
+        className="text-xl font-bold tabular-nums"
+        style={color ? { color } : undefined}
+      >
+        {value.toLocaleString()}
+      </span>
+      <span className="text-xs text-text-muted capitalize">{label}</span>
+    </div>
+  );
+}
+
+function ProjectList({
+  clusters,
+  selectedProject,
+  onSelectProject,
+}: {
+  clusters: ClusterMeta[];
+  selectedProject: string | null;
+  onSelectProject: (p: string | null) => void;
+}) {
+  return (
+    <>
+      <div className="h-px bg-border my-1" />
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-mono uppercase tracking-wide text-text-muted">
+          Projects
+        </span>
+        {selectedProject && (
+          <button
+            onClick={() => onSelectProject(null)}
+            className="text-[9px] font-mono text-accent cursor-pointer hover:underline"
+          >
+            Clear filter
+          </button>
+        )}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {clusters.map((c) => {
+          const isSel = selectedProject === c.id;
+          return (
+            <button
+              key={c.id}
+              onClick={() => onSelectProject(isSel ? null : c.id)}
+              className={`flex items-center justify-between py-1 px-1.5 gap-2 rounded-md cursor-pointer text-left transition-all duration-150 border-none ${
+                isSel ? 'bg-accent/15' : 'bg-transparent hover:bg-white/[0.04]'
+              }`}
+            >
+              <span
+                className={`text-xs truncate ${isSel ? 'text-accent font-semibold' : 'text-text-primary'}`}
+                title={c.id}
+              >
+                {c.label}
+              </span>
+              <span
+                className={`text-[9px] tabular-nums ${isSel ? 'text-accent' : 'text-text-muted'}`}
+              >
+                {c.docCount}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/pages/Planets.tsx
+++ b/src/pages/Planets.tsx
@@ -1,91 +1,75 @@
-import { useMemo } from 'react';
-import { KnowledgeMap } from 'knowledge-map-3d';
-import type { MapDocument, ClusterMeta, NebulaMeta } from 'knowledge-map-3d';
-
-function demoData(): { documents: MapDocument[]; clusters: ClusterMeta[]; nebulae: NebulaMeta[] } {
-  const clusterPositions = [
-    { id: 'c-core', label: 'Oracle Core', cx: 0, cy: 0, cz: 0 },
-    { id: 'c-routes', label: 'Routes', cx: 14, cy: 2, cz: -4 },
-    { id: 'c-plugins', label: 'Plugins', cx: -12, cy: -3, cz: 6 },
-    { id: 'c-tests', label: 'Tests', cx: 3, cy: 12, cz: 3 },
-  ];
-
-  const docs: MapDocument[] = [];
-  const clusters: ClusterMeta[] = [];
-
-  clusterPositions.forEach((c, ci) => {
-    const n = 8 + (ci % 3);
-    for (let i = 0; i < n; i++) {
-      const angle = (i / n) * Math.PI * 2;
-      const r = 2 + (i % 3);
-      docs.push({
-        id: `${c.id}-d${i}`,
-        type: ci === 0 ? 'concept' : ci === 1 ? 'route' : ci === 2 ? 'plugin' : 'test',
-        sourceFile: `${c.label}/item-${i}.ts`,
-        concepts: [c.label.toLowerCase()],
-        project: 'arra-oracle-v3',
-        x: c.cx + Math.cos(angle) * r,
-        y: c.cy + Math.sin(angle) * r * 0.5,
-        z: c.cz + Math.sin(angle * 2) * r * 0.3,
-        clusterId: c.id,
-        orbitRadius: r,
-        orbitSpeed: 0.002 + (i % 5) * 0.0005,
-        orbitPhase: angle,
-        orbitTilt: (i % 7) * 0.1,
-        parentId: null,
-        moonCount: 0,
-        createdAt: Date.now() - i * 86_400_000,
-        contentLength: 1000 + i * 200,
-      });
-    }
-    clusters.push({
-      id: c.id,
-      label: c.label,
-      docCount: n,
-      cx: c.cx,
-      cy: c.cy,
-      cz: c.cz,
-      radius: 8,
-      concepts: [c.label.toLowerCase()],
-      starDocId: null,
-    });
-  });
-
-  const nebulae: NebulaMeta[] = [
-    {
-      id: 'n-core-routes',
-      clusterA: 'c-core',
-      clusterB: 'c-routes',
-      cx: 7,
-      cy: 1,
-      cz: -2,
-      strength: 0.6,
-      color: '#7c3aed',
-    },
-    {
-      id: 'n-core-plugins',
-      clusterA: 'c-core',
-      clusterB: 'c-plugins',
-      cx: -6,
-      cy: -1.5,
-      cz: 3,
-      strength: 0.4,
-      color: '#f59e0b',
-    },
-  ];
-
-  return { documents: docs, clusters, nebulae };
-}
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { usePlanetsData } from '../hooks/usePlanetsData';
+import { usePlanetsSearch } from '../hooks/usePlanetsSearch';
+import { PlanetsCanvas } from '../components/planets/PlanetsCanvas';
+import { PlanetsSidebar } from '../components/planets/PlanetsSidebar';
+import { PlanetsHUD } from '../components/planets/PlanetsHUD';
+import { PlanetsLoading, PlanetsEmpty } from '../components/planets/PlanetsEmpty';
+import { NebulaLegend } from '../components/planets/NebulaLegend';
+import { TYPE_COLORS } from '../lib/type-colors';
 
 export function Planets() {
-  const { documents, clusters, nebulae } = useMemo(demoData, []);
+  const navigate = useNavigate();
+  const data = usePlanetsData();
+  const search = usePlanetsSearch();
+  const [visibleTypes, setVisibleTypes] = useState<Set<string>>(() => new Set(Object.keys(TYPE_COLORS)));
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+
+  const toggleType = useCallback((t: string) => {
+    setVisibleTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(t)) next.delete(t); else next.add(t);
+      return next;
+    });
+  }, []);
+
+  const filteredDocs = useMemo(
+    () => data.documents.filter((d) =>
+      visibleTypes.has(d.type) && (!selectedProject || d.project === selectedProject)),
+    [data.documents, visibleTypes, selectedProject],
+  );
+
+  const typeCounts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const d of data.documents) c[d.type] = (c[d.type] || 0) + 1;
+    return c;
+  }, [data.documents]);
+
+  if (data.loading) return <PlanetsLoading />;
+  if (data.error) return <PlanetsEmpty message={data.error} />;
+  if (data.documents.length === 0) return <PlanetsEmpty />;
+
   return (
-    <div className="w-full h-[calc(100vh-110px)] bg-black">
-      <KnowledgeMap
-        documents={documents}
-        clusters={clusters}
-        nebulae={nebulae}
-        embedded={false}
+    <div className="flex h-[calc(100vh-64px)] overflow-hidden bg-black">
+      <div className="flex-1 relative overflow-hidden">
+        <PlanetsCanvas
+          documents={filteredDocs}
+          clusters={data.clusters}
+          nebulae={data.nebulae}
+          highlightIds={search.matchIds}
+          onDocumentClick={(doc) => navigate(`/doc/${doc.id}`)}
+        />
+        <PlanetsHUD
+          query={search.query}
+          onQueryChange={search.setQuery}
+          onClear={search.clear}
+          matchCount={search.matchIds.size}
+          visibleTypes={visibleTypes}
+          onToggleType={toggleType}
+        />
+        <NebulaLegend />
+      </div>
+      <PlanetsSidebar
+        stats={data.stats}
+        clusters={data.clusters}
+        totalDocs={data.documents.length}
+        typeCounts={typeCounts}
+        matchCount={search.matchIds.size}
+        selectedProject={selectedProject}
+        onSelectProject={setSelectedProject}
+        model={data.model}
+        onSetModel={data.setModel}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Splits `/planets` into 6 focused components (each ≤200 LOC) + thin orchestrator page (≤80 LOC).
- Wires `usePlanetsData()` + `usePlanetsSearch()` hooks into the UI with client-side type/project filtering.
- Planet click navigates to `/doc/:id`; search results highlight via `KnowledgeMap.highlightIds`.
- Closes #36 (part 3 of 4, after cartographer #37 + navigator #38).

## Files
| File | LOC |
|------|----:|
| `src/components/planets/PlanetsCanvas.tsx` | 36 |
| `src/components/planets/PlanetsSidebar.tsx` | 153 |
| `src/components/planets/EngineList.tsx` | 66 |
| `src/components/planets/PlanetsHUD.tsx` | 85 |
| `src/components/planets/PlanetsEmpty.tsx` | 40 |
| `src/components/planets/NebulaLegend.tsx` | 49 |
| `src/pages/Planets.tsx` (rewrite) | 76 |

## Test plan
- [x] `bun run build` passes (tsc -b + vite build)
- [x] Bundle: 1,779.40 kB raw / 502.25 kB gzip
- [ ] Dev-browser smoke (handoff to prover / task #4)
- [ ] Playwright e2e (handoff to prover / task #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)