### PR TITLE
feat(nav): add Compare item linking to vector.*/compare

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,7 +41,12 @@ export function isStudioHost(): boolean {
 /** Paths that should jump cross-origin to vector.* from the studio bundle. */
 function isVectorPath(path: string): boolean {
   const clean = path.split('?')[0];
-  return clean === '/playground' || clean.startsWith('/playground/');
+  return (
+    clean === '/playground' ||
+    clean.startsWith('/playground/') ||
+    clean === '/compare' ||
+    clean.startsWith('/compare/')
+  );
 }
 
 type NavSet = { main: NavItem[]; tools: NavItem[] };


### PR DESCRIPTION
## Summary
- Route the existing `Compare` tools-menu item cross-origin to `vector.buildwithoracle.com/compare` when rendered from studio.*
- Extends `isVectorPath()` (path-based cross-origin routing) to include `/compare` + `/compare/*`, alongside the existing `/playground` handling.
- No new menu entry — `Compare` already sits in the Tools fallback; this just makes the link work.

Companion to ui-vector-oracle-studio `feat(compare): page + sub-nav + router wiring`.

## Test plan
- [x] `bun run build` passes
- [ ] On `studio.buildwithoracle.com`, Tools → Compare navigates to `vector.buildwithoracle.com/compare?host=…`
- [ ] No regression on Tools → Playground (still cross-origins to vector.*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)