### PR TITLE
perf: run_worker_first on ASSETS binding

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -17,6 +17,7 @@
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
   }
 }


### PR DESCRIPTION
Without this, CF Workers Assets bypasses the worker for exact file matches. Cache-Control from #42 wasn't applying to /assets/*.js. Enable run_worker_first so worker sees every request.