### PR TITLE
feat: client API cache layer + bust-on-write invalidation (Phase 2 of #41, fixes Header menu TTL bug)

### DIFF
--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -7,10 +7,16 @@
 //
 // See ./host.ts for the full API (setStoredHost, clearStoredHost, getRecentHosts, wsUrl…).
 import { apiUrl } from './host';
+import { cached } from '../lib/cache';
 export { apiUrl } from './host';
 
 /** Resolved base for Oracle API (e.g. `/api` or `https://mba.wg:47778/api`). */
 export const API_BASE = apiUrl('/api');
+
+// Cache TTLs — see Phase 2 of #41. Invalidation tags drive `cacheBus.invalidate(tag)`.
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+const TEN_MIN = 10 * 60 * 1000;
 
 /** Strip project prefix from source_file for display (vault-indexed cross-project docs) */
 export function stripProjectPrefix(sourceFile: string, project?: string): string {
@@ -76,27 +82,35 @@ export async function search(
 ): Promise<SearchResult & { mode?: string; model?: string; warning?: string }> {
   const params = new URLSearchParams({ q: query, type, limit: String(limit), mode });
   if (model) params.set('model', model);
-  const res = await fetch(`${API_BASE}/search?${params}`);
-  return res.json();
+  const qs = params.toString();
+  return cached(`search:${qs}`, TEN_MIN, async () => {
+    const res = await fetch(`${API_BASE}/search?${qs}`);
+    return res.json();
+  }, { tag: 'search' });
 }
 
 // List/browse documents
 export async function list(type: string = 'all', limit: number = 20, offset: number = 0): Promise<{ results: Document[]; total: number }> {
   const params = new URLSearchParams({ type, limit: String(limit), offset: String(offset) });
-  const res = await fetch(`${API_BASE}/list?${params}`);
-  return res.json();
+  const qs = params.toString();
+  return cached(`list:${type}:${qs}`, ONE_HOUR, async () => {
+    const res = await fetch(`${API_BASE}/list?${qs}`);
+    return res.json();
+  }, { tag: `list:${type}` });
 }
 
 // Get stats
 export async function getStats(): Promise<Stats> {
-  const res = await fetch(`${API_BASE}/stats`);
-  if (!res.ok) {
-    throw new Error(`Server error: ${res.status}`);
-  }
-  return res.json();
+  return cached('stats', ONE_HOUR, async () => {
+    const res = await fetch(`${API_BASE}/stats`);
+    if (!res.ok) {
+      throw new Error(`Server error: ${res.status}`);
+    }
+    return res.json();
+  }, { tag: 'stats' });
 }
 
-// Get random wisdom
+// Get random wisdom — no cache (always return a fresh reflection).
 export async function reflect(): Promise<Document> {
   const res = await fetch(`${API_BASE}/reflect`);
   return res.json();
@@ -141,15 +155,20 @@ export async function getFile(filePath: string, project?: string): Promise<{ con
 
 // Get document by ID
 export async function getDoc(id: string): Promise<Document & { error?: string }> {
-  const res = await fetch(`${API_BASE}/doc/${encodeURIComponent(id)}`);
-  return res.json();
+  return cached(`doc:${id}`, ONE_DAY, async () => {
+    const res = await fetch(`${API_BASE}/doc/${encodeURIComponent(id)}`);
+    return res.json();
+  }, { tag: 'doc' });
 }
 
 // Get similar documents (vector nearest neighbors)
 export async function getSimilar(docId: string, limit: number = 5): Promise<{ results: Document[]; docId: string }> {
   const params = new URLSearchParams({ id: docId, limit: String(limit) });
-  const res = await fetch(`${API_BASE}/similar?${params}`);
-  return res.json();
+  const qs = params.toString();
+  return cached(`similar:${docId}:${limit}`, ONE_DAY, async () => {
+    const res = await fetch(`${API_BASE}/similar?${qs}`);
+    return res.json();
+  }, { tag: 'similar' });
 }
 
 // Get knowledge map data (2D projection)
@@ -185,8 +204,10 @@ export async function getOracles(): Promise<{
   total_projects: number;
   total_identities: number;
 }> {
-  const res = await fetch(`${API_BASE}/oracles`);
-  return res.json();
+  return cached('oracles', ONE_DAY, async () => {
+    const res = await fetch(`${API_BASE}/oracles`);
+    return res.json();
+  }, { tag: 'oracles' });
 }
 
 export async function getMap(): Promise<{ documents: MapDocument[]; total: number }> {
@@ -196,8 +217,11 @@ export async function getMap(): Promise<{ documents: MapDocument[]; total: numbe
 
 export async function getMap3d(model?: string): Promise<{ documents: MapDocument[]; total: number; pca_info?: any }> {
   const params = model ? `?model=${encodeURIComponent(model)}` : '';
-  const res = await fetch(`${API_BASE}/map3d${params}`);
-  return res.json();
+  const key = `map3d:${model ?? 'default'}`;
+  return cached(key, ONE_DAY, async () => {
+    const res = await fetch(`${API_BASE}/map3d${params}`);
+    return res.json();
+  }, { tag: 'map3d', store: 'idb' });
 }
 
 // Dashboard types

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { API_BASE } from '../api/oracle';
 import { apiUrl, hostLabel, isDefault, setStoredHost, clearStoredHost } from '../api/host';
+import { cached } from '../lib/cache';
 
 type NavItem = { path: string; label: string; studio?: string };
 
@@ -26,8 +27,8 @@ const FALLBACK_TOOLS: NavItem[] = [
   { path: '/schedule', label: 'Schedule' },
 ];
 
-const CACHE_KEY = 'oracle_studio_menu_v1';
-const CACHE_TTL_MS = 5 * 60 * 1000;
+const MENU_CACHE_KEY = 'header:menu';
+const MENU_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 const VECTOR_ORIGIN = 'https://vector.buildwithoracle.com';
 
@@ -59,23 +60,33 @@ type MenuApiItem = {
   studio?: string;
 };
 
-function readCachedNav(): NavSet | null {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed.ts !== 'number') return null;
-    if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
-    return parsed.nav as NavSet;
-  } catch {
-    return null;
+function buildNavSet(items: MenuApiItem[]): NavSet {
+  const main: Array<NavItem & { order: number }> = [];
+  const tools: Array<NavItem & { order: number }> = [];
+  for (const item of items) {
+    if (!item || typeof item.path !== 'string' || typeof item.label !== 'string') continue;
+    const bucket = item.group === 'tools' ? tools : item.group === 'main' ? main : null;
+    if (!bucket) continue;
+    const entry: NavItem & { order: number } = {
+      path: item.path,
+      label: item.label,
+      order: typeof item.order === 'number' ? item.order : 999,
+    };
+    if (typeof item.studio === 'string' && item.studio) entry.studio = item.studio;
+    bucket.push(entry);
   }
-}
-
-function writeCachedNav(nav: NavSet): void {
-  try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), nav }));
-  } catch {}
+  const byOrder = (a: { order: number }, b: { order: number }) => a.order - b.order;
+  main.sort(byOrder);
+  tools.sort(byOrder);
+  const strip = ({ path, label, studio }: NavItem & { order: number }): NavItem =>
+    studio ? { path, label, studio } : { path, label };
+  const mainItems = main.map(strip);
+  return {
+    main: mainItems.some((n) => n.path === '/' && !n.studio)
+      ? mainItems
+      : [{ path: '/', label: 'Overview' }, ...mainItems],
+    tools: tools.map(strip),
+  };
 }
 
 export function Header() {
@@ -84,7 +95,7 @@ export function Header() {
   const [toolsOpen, setToolsOpen] = useState(false);
   const [stats, setStats] = useState({ searches: 0, learnings: 0 });
   const [backendVersion, setBackendVersion] = useState<string | null>(null);
-  const [nav, setNav] = useState<NavSet>(() => readCachedNav() ?? { main: FALLBACK_NAV, tools: FALLBACK_TOOLS });
+  const [nav, setNav] = useState<NavSet>({ main: FALLBACK_NAV, tools: FALLBACK_TOOLS });
 
   useEffect(() => {
     let cancelled = false;
@@ -103,41 +114,24 @@ export function Header() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(apiUrl('/api/menu'));
-        if (!res.ok) return;
-        const data = await res.json();
+        // Cached via the shared client cache — 24h TTL, tag='menu'.
+        // MenuEditor / GistSourceConfig call `cacheBus.invalidate('menu')` on write,
+        // so edits bust this immediately instead of waiting for the old 5-min TTL.
+        const data = await cached<{ items?: MenuApiItem[] }>(
+          MENU_CACHE_KEY,
+          MENU_CACHE_TTL_MS,
+          async () => {
+            const res = await fetch(apiUrl('/api/menu'));
+            if (!res.ok) throw new Error(`menu ${res.status}`);
+            return res.json();
+          },
+          { tag: 'menu' },
+        );
         const items: MenuApiItem[] = Array.isArray(data?.items) ? data.items : [];
         if (cancelled || items.length === 0) return;
-        const main: Array<NavItem & { order: number }> = [];
-        const tools: Array<NavItem & { order: number }> = [];
-        for (const item of items) {
-          if (!item || typeof item.path !== 'string' || typeof item.label !== 'string') continue;
-          const bucket = item.group === 'tools' ? tools : item.group === 'main' ? main : null;
-          if (!bucket) continue;
-          const entry: NavItem & { order: number } = {
-            path: item.path,
-            label: item.label,
-            order: typeof item.order === 'number' ? item.order : 999,
-          };
-          if (typeof item.studio === 'string' && item.studio) entry.studio = item.studio;
-          bucket.push(entry);
-        }
-        const byOrder = (a: { order: number }, b: { order: number }) => a.order - b.order;
-        main.sort(byOrder);
-        tools.sort(byOrder);
-        const strip = ({ path, label, studio }: NavItem & { order: number }): NavItem =>
-          studio ? { path, label, studio } : { path, label };
-        const mainItems = main.map(strip);
-        const next = {
-          main: mainItems.some((n) => n.path === '/' && !n.studio)
-            ? mainItems
-            : [{ path: '/', label: 'Overview' }, ...mainItems],
-          tools: tools.map(strip),
-        };
-        setNav(next);
-        writeCachedNav(next);
+        setNav(buildNavSet(items));
       } catch {
-        // Backend unreachable — keep fallback/cached nav.
+        // Backend unreachable — keep fallback nav.
       }
     })();
     return () => { cancelled = true; };

--- a/src/components/menu/GistSourceConfig.tsx
+++ b/src/components/menu/GistSourceConfig.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { API_BASE } from '../../api/oracle';
+import { cacheBus } from '../../lib/cache';
 
 interface SourceInfo {
   url: string | null;
@@ -75,6 +76,7 @@ export function GistSourceConfig({ onChanged, showToast }: Props) {
         body: JSON.stringify({ url, mode }),
       });
       if (!res.ok) throw new Error(`load ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast(`Loaded (${mode})`);
       await fetchSource();
       await onChanged();
@@ -87,6 +89,7 @@ export function GistSourceConfig({ onChanged, showToast }: Props) {
     try {
       const res = await fetch(`${API_BASE}/menu/source`, { method: 'DELETE' });
       if (!res.ok) throw new Error(`clear ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Cleared');
       await fetchSource();
       await onChanged();
@@ -99,6 +102,7 @@ export function GistSourceConfig({ onChanged, showToast }: Props) {
     try {
       const res = await fetch(`${API_BASE}/menu/reload`, { method: 'POST' });
       if (!res.ok) throw new Error(`reload ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Reloaded');
       await fetchSource();
       await onChanged();
@@ -112,6 +116,7 @@ export function GistSourceConfig({ onChanged, showToast }: Props) {
     try {
       const res = await fetch(`${API_BASE}/menu/reset-all`, { method: 'POST' });
       if (!res.ok) throw new Error(`reset-all ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Reset to defaults');
       await fetchSource();
       await onChanged();

--- a/src/lib/cache/__tests__/bus.test.ts
+++ b/src/lib/cache/__tests__/bus.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'bun:test';
+import { installDomMocks } from './setup';
+
+installDomMocks();
+
+const { cacheBus } = await import('../bus');
+
+describe('cacheBus', () => {
+  it('delivers invalidation events to listeners', () => {
+    const events: string[] = [];
+    const off = cacheBus.on((ev) => { events.push(ev.tag); });
+    cacheBus.invalidate('menu');
+    cacheBus.invalidate('stats');
+    off();
+    cacheBus.invalidate('menu'); // post-off: should not deliver
+    expect(events).toEqual(['menu', 'stats']);
+  });
+
+  it('mirrors events to localStorage for cross-tab', () => {
+    cacheBus.invalidate('oracles');
+    const raw = (globalThis as unknown as { localStorage: Storage }).localStorage.getItem('oracle_cache_bus_v1');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tag).toBe('oracles');
+    expect(typeof parsed.at).toBe('number');
+  });
+
+  it('attachCrossTab returns an unsubscribe function', () => {
+    const off = cacheBus.attachCrossTab();
+    expect(typeof off).toBe('function');
+    off();
+  });
+});

--- a/src/lib/cache/__tests__/cached.test.ts
+++ b/src/lib/cache/__tests__/cached.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { installDomMocks, resetDomMocks } from './setup';
+
+installDomMocks('v1.0.0+test');
+
+const { cached, __resetCachedForTests } = await import('../cached');
+const { cacheBus } = await import('../bus');
+const { localStore } = await import('../local-store');
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+describe('cached()', () => {
+  beforeEach(async () => {
+    resetDomMocks();
+    __resetCachedForTests();
+    await localStore.clear();
+  });
+
+  it('fetches on first call and caches', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return { n: calls }; };
+    const a = await cached('k', 10_000, fetcher);
+    const b = await cached('k', 10_000, fetcher);
+    expect(a.n).toBe(1);
+    expect(b.n).toBe(1); // served from cache
+    expect(calls).toBe(1);
+  });
+
+  it('re-fetches after TTL expires (stale-while-revalidate)', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    const v1 = await cached('swr', 5, fetcher);
+    expect(v1).toBe(1);
+    await sleep(10);
+    // Stale: returns cached value immediately but triggers background refetch.
+    const v2 = await cached('swr', 5, fetcher);
+    expect(v2).toBe(1);
+    // Wait for background refetch to finish.
+    await sleep(20);
+    const v3 = await cached('swr', 10_000, fetcher);
+    expect(v3).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  it('version mismatch invalidates entry', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('vk', 10_000, fetcher);
+    expect(calls).toBe(1);
+
+    // Simulate a new build version.
+    (globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'v2.0.0+test';
+    const v = await cached('vk', 10_000, fetcher);
+    expect(v).toBe(2);
+    expect(calls).toBe(2);
+
+    (globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'v1.0.0+test';
+  });
+
+  it('cacheBus.invalidate(tag) drops tagged entries', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('menu-a', 10_000, fetcher, { tag: 'menu' });
+    await cached('menu-b', 10_000, fetcher, { tag: 'menu' });
+    expect(calls).toBe(2);
+
+    cacheBus.invalidate('menu');
+    // Allow async listeners to run.
+    await sleep(5);
+
+    const v = await cached('menu-a', 10_000, fetcher, { tag: 'menu' });
+    expect(v).toBe(3);
+  });
+
+  it('ttl <= 0 bypasses the cache', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('nocache', 0, fetcher);
+    await cached('nocache', 0, fetcher);
+    expect(calls).toBe(2);
+  });
+
+  it('de-dupes concurrent initial fetches', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; await sleep(20); return 'x'; };
+    const [a, b, c] = await Promise.all([
+      cached('dedup', 10_000, fetcher),
+      cached('dedup', 10_000, fetcher),
+      cached('dedup', 10_000, fetcher),
+    ]);
+    expect(a).toBe('x');
+    expect(b).toBe('x');
+    expect(c).toBe('x');
+    expect(calls).toBe(1);
+  });
+});

--- a/src/lib/cache/__tests__/local-store.test.ts
+++ b/src/lib/cache/__tests__/local-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { installDomMocks, resetDomMocks } from './setup';
+
+installDomMocks();
+
+// Import after mocks are installed.
+const { localStore, estimateBytes } = await import('../local-store');
+
+describe('localStore', () => {
+  beforeEach(() => { resetDomMocks(); });
+
+  it('round-trips an entry', async () => {
+    await localStore.set('k1', { v: 'v0', ts: 1, ttl: 1000, data: { hello: 'world' } });
+    const got = await localStore.get<{ hello: string }>('k1');
+    expect(got?.data.hello).toBe('world');
+    expect(got?.ttl).toBe(1000);
+  });
+
+  it('returns null for missing keys', async () => {
+    expect(await localStore.get('missing')).toBeNull();
+  });
+
+  it('deletes entries', async () => {
+    await localStore.set('k2', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.del('k2');
+    expect(await localStore.get('k2')).toBeNull();
+  });
+
+  it('keys() returns only cache-prefixed keys', async () => {
+    await localStore.set('a', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.set('b', { v: 'v0', ts: 1, ttl: 1, data: 2 });
+    const keys = await localStore.keys();
+    expect(keys.sort()).toEqual(['a', 'b']);
+  });
+
+  it('clear() removes all cache entries', async () => {
+    await localStore.set('a', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.clear();
+    expect((await localStore.keys()).length).toBe(0);
+  });
+
+  it('estimateBytes grows with payload', () => {
+    expect(estimateBytes('x')).toBeGreaterThan(0);
+    expect(estimateBytes('xxxxxxxxxx')).toBeGreaterThan(estimateBytes('x'));
+  });
+});

--- a/src/lib/cache/__tests__/setup.ts
+++ b/src/lib/cache/__tests__/setup.ts
@@ -1,0 +1,35 @@
+// Minimal DOM-ish mocks for bun:test — only what the cache module touches.
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  key(i: number): string | null {
+    return Array.from(this.store.keys())[i] ?? null;
+  }
+  getItem(k: string): string | null { return this.store.get(k) ?? null; }
+  setItem(k: string, v: string): void { this.store.set(k, String(v)); }
+  removeItem(k: string): void { this.store.delete(k); }
+  clear(): void { this.store.clear(); }
+}
+
+export function installDomMocks(version = 'v0.0.0+test'): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.__APP_VERSION__ = version;
+  g.localStorage = new MemoryStorage();
+  g.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  g.indexedDB = undefined; // force localStore path; idb tested separately
+  g.Blob = class MockBlob {
+    size: number;
+    constructor(parts: unknown[]) {
+      this.size = parts.reduce<number>((sum, p) => sum + (typeof p === 'string' ? p.length : 0), 0);
+    }
+  } as unknown as typeof Blob;
+}
+
+export function resetDomMocks(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  (g.localStorage as MemoryStorage | undefined)?.clear();
+}

--- a/src/lib/cache/bus.ts
+++ b/src/lib/cache/bus.ts
@@ -1,0 +1,55 @@
+// Simple pub/sub bus for cache invalidation. Components fire
+// `cacheBus.invalidate('menu')` after a write; cached-wrapped readers
+// listen and drop any entry whose tag matches.
+
+import type { InvalidationEvent } from './types';
+
+type Listener = (ev: InvalidationEvent) => void;
+
+class CacheBus {
+  private listeners = new Set<Listener>();
+
+  /** Fire an invalidation event for `tag`. Also mirrors to other tabs via storage event. */
+  invalidate(tag: string): void {
+    const ev: InvalidationEvent = { tag, at: Date.now() };
+    for (const fn of this.listeners) {
+      try { fn(ev); } catch { /* ignore */ }
+    }
+    // Cross-tab: bump a well-known localStorage key so other tabs' `storage`
+    // listeners can pick it up and re-broadcast locally.
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('oracle_cache_bus_v1', JSON.stringify(ev));
+      }
+    } catch { /* ignore */ }
+  }
+
+  on(fn: Listener): () => void {
+    this.listeners.add(fn);
+    return () => { this.listeners.delete(fn); };
+  }
+
+  /** Rebroadcast a cross-tab storage event locally. */
+  private replay(raw: string | null): void {
+    if (!raw) return;
+    try {
+      const ev = JSON.parse(raw) as InvalidationEvent;
+      if (!ev || typeof ev.tag !== 'string') return;
+      for (const fn of this.listeners) {
+        try { fn(ev); } catch { /* ignore */ }
+      }
+    } catch { /* ignore */ }
+  }
+
+  /** Wire `storage` event listener — call once at app start. */
+  attachCrossTab(): () => void {
+    if (typeof window === 'undefined') return () => {};
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'oracle_cache_bus_v1') this.replay(e.newValue);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }
+}
+
+export const cacheBus = new CacheBus();

--- a/src/lib/cache/cached.ts
+++ b/src/lib/cache/cached.ts
@@ -1,0 +1,96 @@
+// cached() — stale-while-revalidate wrapper around a fetcher.
+//   fresh (age < ttl)  → return cached, no refetch.
+//   stale (age ≥ ttl)  → return cached AND kick off a background refetch.
+//   missing / version mismatch → await fetcher, write, return.
+//   cacheBus.invalidate(tag) drops every entry with that tag.
+// Storage: auto (local if ≤50KB, else idb). Override via policy.store.
+
+import type { CacheEntry, CachePolicy } from './types';
+import { localStore, estimateBytes } from './local-store';
+import { idbStore } from './idb-store';
+import { cacheBus } from './bus';
+
+const SIZE_THRESHOLD_BYTES = 50 * 1024;
+
+function appVersion(): string {
+  try { return typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'; }
+  catch { return 'dev'; }
+}
+
+// tag → keys index (for O(1) tag invalidation); inflight map (de-dupes concurrent fetchers).
+const tagIndex = new Map<string, Set<string>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+cacheBus.on(async (ev) => {
+  const keys = tagIndex.get(ev.tag);
+  if (!keys || keys.size === 0) return;
+  const snapshot = Array.from(keys);
+  keys.clear();
+  for (const k of snapshot) {
+    try { await localStore.del(k); } catch { /* ignore */ }
+    try { await idbStore.del(k); } catch { /* ignore */ }
+    inflight.delete(k);
+  }
+});
+
+async function readEntry<T>(key: string): Promise<CacheEntry<T> | null> {
+  return (await localStore.get<T>(key)) ?? (await idbStore.get<T>(key));
+}
+
+async function writeEntry<T>(key: string, entry: CacheEntry<T>, policy: CachePolicy): Promise<void> {
+  if (policy.store === 'idb') { await idbStore.set(key, entry); return; }
+  if (policy.store === 'local') { await localStore.set(key, entry); return; }
+  if (estimateBytes(entry.data) > SIZE_THRESHOLD_BYTES) { await idbStore.set(key, entry); return; }
+  try { await localStore.set(key, entry); }
+  catch { await idbStore.set(key, entry); }
+}
+
+async function fetchAndStore<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = (async () => {
+    const data = await fetcher();
+    const entry: CacheEntry<T> = { v: appVersion(), ts: Date.now(), ttl: ttlMs, tag: policy.tag, data };
+    try { await writeEntry(key, entry, policy); } catch { /* ignore */ }
+    return data;
+  })();
+  inflight.set(key, p);
+  try { return await p; } finally { inflight.delete(key); }
+}
+
+function refreshInBackground<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): void {
+  if (inflight.has(key)) return;
+  const p = fetchAndStore(key, ttlMs, fetcher, policy).catch(() => { /* swallow */ });
+  inflight.set(key, p);
+  void p.finally(() => { inflight.delete(key); });
+}
+
+/** Wrap `fetcher` with stale-while-revalidate caching keyed by `key`. */
+export async function cached<T>(
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>,
+  policy: CachePolicy = {},
+): Promise<T> {
+  if (policy.tag) {
+    let set = tagIndex.get(policy.tag);
+    if (!set) { set = new Set(); tagIndex.set(policy.tag, set); }
+    set.add(key);
+  }
+  if (ttlMs <= 0) return fetcher();
+
+  const entry = await readEntry<T>(key);
+  const v = appVersion();
+  if (entry && entry.v === v) {
+    if (Date.now() - entry.ts < ttlMs) return entry.data;
+    refreshInBackground(key, ttlMs, fetcher, policy);
+    return entry.data;
+  }
+  return fetchAndStore(key, ttlMs, fetcher, policy);
+}
+
+/** Test-only reset. */
+export function __resetCachedForTests(): void {
+  tagIndex.clear();
+  inflight.clear();
+}

--- a/src/lib/cache/idb-store.ts
+++ b/src/lib/cache/idb-store.ts
@@ -1,0 +1,94 @@
+// IndexedDB adapter for the client cache — used for larger payloads
+// (>50KB) that would bloat localStorage. Single object-store keyed by
+// string. Gracefully no-ops when IndexedDB is unavailable.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const DB_NAME = 'oracle_cache_v1';
+const STORE = 'entries';
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve) => {
+    try {
+      if (typeof indexedDB === 'undefined') { resolve(null); return; }
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+      req.onblocked = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+  return dbPromise;
+}
+
+function tx(db: IDBDatabase, mode: IDBTransactionMode): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function promisify<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export const idbStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const db = await openDb();
+    if (!db) return null;
+    try {
+      const val = await promisify<unknown>(tx(db, 'readonly').get(key));
+      if (!val || typeof val !== 'object') return null;
+      const e = val as CacheEntry<T>;
+      if (typeof e.ts !== 'number' || typeof e.ttl !== 'number') return null;
+      return e;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').put(entry, key)); } catch {
+      throw new Error('idbStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').delete(key)); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const db = await openDb();
+    if (!db) return [];
+    try {
+      const req = tx(db, 'readonly').getAllKeys();
+      const arr = await promisify<IDBValidKey[]>(req);
+      return arr.map((k) => String(k));
+    } catch {
+      return [];
+    }
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').clear()); } catch { /* ignore */ }
+  },
+};
+
+/** Reset the module singleton — test-only; not exported from the barrel. */
+export function __resetIdbForTests(): void {
+  dbPromise = null;
+}

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,0 +1,6 @@
+// Barrel for the client cache module.
+export { cached } from './cached';
+export { cacheBus } from './bus';
+export { localStore } from './local-store';
+export { idbStore } from './idb-store';
+export type { CacheEntry, CachePolicy, InvalidationEvent, CacheStore } from './types';

--- a/src/lib/cache/local-store.ts
+++ b/src/lib/cache/local-store.ts
@@ -1,0 +1,87 @@
+// localStorage adapter for the client cache.
+//
+// Keys are namespaced under `oracle_cache/v1:` so the store is easy to spot
+// in devtools and can be wiped atomically via `clear()`.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const PREFIX = 'oracle_cache/v1:';
+
+function storage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export const localStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const ls = storage();
+    if (!ls) return null;
+    try {
+      const raw = ls.getItem(PREFIX + key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as CacheEntry<T>;
+      if (!parsed || typeof parsed.ts !== 'number' || typeof parsed.ttl !== 'number') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      ls.setItem(PREFIX + key, JSON.stringify(entry));
+    } catch {
+      // Quota exceeded or other failure — swallow; caller may fall back to idb.
+      throw new Error('localStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try { ls.removeItem(PREFIX + key); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const ls = storage();
+    if (!ls) return [];
+    const out: string[] = [];
+    try {
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) out.push(k.slice(PREFIX.length));
+      }
+    } catch { /* ignore */ }
+    return out;
+  },
+
+  async clear(): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      const doomed: string[] = [];
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) doomed.push(k);
+      }
+      for (const k of doomed) ls.removeItem(k);
+    } catch { /* ignore */ }
+  },
+};
+
+/** Estimate the byte size of a value once JSON-encoded. */
+export function estimateBytes(value: unknown): number {
+  try {
+    return new Blob([JSON.stringify(value)]).size;
+  } catch {
+    try { return JSON.stringify(value).length * 2; } catch { return 0; }
+  }
+}
+
+export const LOCAL_STORE_PREFIX = PREFIX;

--- a/src/lib/cache/types.ts
+++ b/src/lib/cache/types.ts
@@ -1,0 +1,34 @@
+// Client-side API cache — shared types.
+
+export interface CacheEntry<T = unknown> {
+  /** App build version (from __APP_VERSION__) at write time. */
+  v: string;
+  /** ISO epoch ms when this entry was written. */
+  ts: number;
+  /** TTL in ms — entry is fresh while `now - ts < ttl`. */
+  ttl: number;
+  /** Invalidation tag (optional). */
+  tag?: string;
+  /** The cached value. */
+  data: T;
+}
+
+export interface CachePolicy {
+  /** Invalidation tag for bulk clear via cacheBus. */
+  tag?: string;
+  /** Force a specific backing store. Default: auto — local first, idb if payload > 50KB. */
+  store?: 'local' | 'idb';
+}
+
+export interface InvalidationEvent {
+  tag: string;
+  at: number;
+}
+
+export interface CacheStore {
+  get<T>(key: string): Promise<CacheEntry<T> | null>;
+  set<T>(key: string, entry: CacheEntry<T>): Promise<void>;
+  del(key: string): Promise<void>;
+  keys(): Promise<string[]>;
+  clear(): Promise<void>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { cacheBus } from './lib/cache'
+
+// Listen for cache-invalidation events from other tabs (e.g. menu edit in tab A
+// should bust the menu cache in tab B).
+cacheBus.attachCrossTab()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/MenuEditor.tsx
+++ b/src/pages/MenuEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { API_BASE } from '../api/oracle';
+import { cacheBus } from '../lib/cache';
 import {
   DndContext,
   closestCenter,
@@ -49,6 +50,7 @@ export function MenuEditor() {
     try {
       const res = await fetch(`${API_BASE}/menu/items/${id}`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify(patch) });
       if (!res.ok) throw new Error(`patch ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Saved'); await load();
     } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
@@ -56,6 +58,7 @@ export function MenuEditor() {
     try {
       const res = await fetch(`${API_BASE}/menu/reset/${id}`, { method: 'POST' });
       if (!res.ok) throw new Error(`reset ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Reset'); await load();
     } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
@@ -64,6 +67,7 @@ export function MenuEditor() {
     try {
       const res = await fetch(`${API_BASE}/menu/items/${id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error(`delete ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Deleted'); await load();
     } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
@@ -73,6 +77,7 @@ export function MenuEditor() {
     try {
       const res = await fetch(`${API_BASE}/menu/items`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ path, label, group: 'main', order: 999, source: 'custom', access: 'public' }) });
       if (!res.ok) throw new Error(`create ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Created'); await load();
     } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
   }
@@ -93,6 +98,7 @@ export function MenuEditor() {
     try {
       const res = await fetch(`${API_BASE}/menu/reorder`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ items: payload }) });
       if (!res.ok) throw new Error(`reorder ${res.status}`);
+      cacheBus.invalidate('menu');
       showToast('Reordered'); await load();
     } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); await load(); }
   }


### PR DESCRIPTION
## Summary

- **Client-side API cache** — `src/lib/cache/` — typed `cached(key, ttlMs, fetcher, { tag, store })` wrapper with SWR semantics. Backed by `localStorage` (fast) with `IndexedDB` fallback for payloads >50KB. Entries stamped with `__APP_VERSION__`, so new deploys bust the cache automatically.
- **Event-driven invalidation** — `cacheBus.invalidate('menu')` drops every entry tagged `'menu'` immediately. Cross-tab via `storage` event.
- **Wired into `src/api/oracle.ts`** — per the issue design:
  | Endpoint | TTL | Tag |
  | --- | --- | --- |
  | `/api/menu` | 24h | `menu` |
  | `/api/stats` | 1h | `stats` |
  | `/api/oracles` | 24h | `oracles` |
  | `/api/list?type=X` | 1h | `list:X` |
  | `/api/map3d?model=X` | 24h (idb) | `map3d` |
  | `/api/similar?id=X` | 24h | `similar` |
  | `/api/doc/:id` | 24h | `doc` |
  | `/api/search` | 10min | `search` |
  | `/api/reflect` | — | (always fresh) |
- **Header menu TTL bug** — the ad-hoc 5-min `localStorage` cache in `Header.tsx` was swallowing `/menu` editor changes for up to 5 minutes. Replaced with `cached()` using 24h TTL + `tag='menu'`. `MenuEditor` and `GistSourceConfig` now call `cacheBus.invalidate('menu')` after every successful write, so edits propagate across the app instantly.

## File budget

All new files obey the per-file cap:
- `types.ts` 34 / 40
- `local-store.ts` 87 / 100
- `idb-store.ts` 94 / 140
- `cached.ts` 96 / 120
- `bus.ts` 55 / 60
- `index.ts` 6 / 20

## Tests

15 new `bun:test` cases in `src/lib/cache/__tests__/`:
- `local-store.test.ts` — round-trip, missing keys, delete, keys(), clear(), byte estimate.
- `bus.test.ts` — listener delivery, cross-tab localStorage mirror, unsubscribe.
- `cached.test.ts` — fresh cache hit, stale-while-revalidate refresh, version-mismatch invalidation, tag invalidation, `ttl <= 0` bypass, concurrent fetch de-dupe.

All 55 unit tests pass (`bun test`).

## Build

- `bunx vite build` — clean.
- `bunx tsc -b` — one pre-existing error in the external `knowledge-map-3d` dep (unchanged by this PR; present on `main` at `2cb0d30`).

## Test plan

- [ ] Edit a menu item in `/menu` → Header nav updates instantly (no 5-min wait).
- [ ] Reload `/menu` within 24h → served from cache, no network trip.
- [ ] Deploy with new `__APP_VERSION__` → all cache entries evicted on next read.
- [ ] Open two tabs → invalidate `menu` in tab A → tab B's Header refreshes.
- [ ] Open DevTools → Application → Local Storage → entries namespaced under `oracle_cache/v1:`, IDB store `oracle_cache_v1`.

Refs #41. Phase 3 (service worker / offline) and vector-side mirror remain as follow-ups per issue.