### PR TITLE
feat(menu): tree UI editor + host filter

### DIFF
--- a/src/components/menu/NodeEditDialog.tsx
+++ b/src/components/menu/NodeEditDialog.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import type { MenuItem } from './SortableRow';
+
+interface Props {
+  item: MenuItem;
+  allItems: MenuItem[];
+  onClose: () => void;
+  onSave: (patch: Partial<MenuItem>) => Promise<void> | void;
+}
+
+const GROUPS = ['main', 'tools', 'admin', 'hidden'];
+
+function isDescendant(candidateId: number, ofId: number, items: MenuItem[]): boolean {
+  if (candidateId === ofId) return true;
+  const children = items.filter((i) => i.parentId === ofId);
+  return children.some((c) => isDescendant(candidateId, c.id, items));
+}
+
+export function NodeEditDialog({ item, allItems, onClose, onSave }: Props) {
+  const [label, setLabel] = useState(item.label);
+  const [path, setPath] = useState(item.path);
+  const [groupKey, setGroupKey] = useState(item.groupKey);
+  const [parentId, setParentId] = useState<number | null>(item.parentId ?? null);
+  const [host, setHost] = useState<string>(item.host ?? '');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose(); }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const parentOptions = allItems.filter((i) => !isDescendant(i.id, item.id, allItems));
+
+  async function submit() {
+    setSaving(true);
+    try {
+      const patch: Partial<MenuItem> = {};
+      if (label !== item.label) patch.label = label;
+      if (path !== item.path) patch.path = path;
+      if (groupKey !== item.groupKey) patch.groupKey = groupKey;
+      if ((parentId ?? null) !== (item.parentId ?? null)) patch.parentId = parentId;
+      const hostTrim = host.trim();
+      const hostFinal = hostTrim === '' ? null : hostTrim;
+      if (hostFinal !== (item.host ?? null)) patch.host = hostFinal;
+      if (Object.keys(patch).length > 0) await onSave(patch);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-xl bg-bg-elevated border border-border shadow-xl p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">Edit menu item</h3>
+          <button onClick={onClose} className="text-text-secondary hover:text-accent text-xl leading-none" aria-label="Close">×</button>
+        </div>
+
+        <label className="block text-sm">
+          <span className="text-text-secondary">Label</span>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            className="mt-1 w-full bg-bg-base border border-border rounded px-3 py-2"
+          />
+        </label>
+
+        <label className="block text-sm">
+          <span className="text-text-secondary">Route (path)</span>
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            className="mt-1 w-full bg-bg-base border border-border rounded px-3 py-2 font-mono text-xs"
+          />
+        </label>
+
+        <label className="block text-sm">
+          <span className="text-text-secondary">Group</span>
+          <select
+            value={groupKey}
+            onChange={(e) => setGroupKey(e.target.value)}
+            className="mt-1 w-full bg-bg-base border border-border rounded px-3 py-2"
+          >
+            {GROUPS.map((g) => <option key={g} value={g}>{g}</option>)}
+          </select>
+        </label>
+
+        <label className="block text-sm">
+          <span className="text-text-secondary">Parent</span>
+          <select
+            value={parentId ?? ''}
+            onChange={(e) => setParentId(e.target.value === '' ? null : Number(e.target.value))}
+            className="mt-1 w-full bg-bg-base border border-border rounded px-3 py-2"
+          >
+            <option value="">(root)</option>
+            {parentOptions.map((p) => (
+              <option key={p.id} value={p.id}>{p.label} — {p.path}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block text-sm">
+          <span className="text-text-secondary">Host</span>
+          <input
+            type="text"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            placeholder="null = all hosts, e.g. vector.*"
+            className="mt-1 w-full bg-bg-base border border-border rounded px-3 py-2 font-mono text-xs"
+          />
+          <p className="text-xs text-text-secondary mt-1">Leave blank for all hosts. Glob patterns supported (e.g. <code>vector.*</code>).</p>
+        </label>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-4 py-2 text-sm rounded border border-border hover:border-accent/40">Cancel</button>
+          <button
+            onClick={submit}
+            disabled={saving}
+            className="px-4 py-2 text-sm rounded bg-accent/20 hover:bg-accent/30 text-accent border border-accent/40 disabled:opacity-50"
+          >{saving ? 'Saving…' : 'Save'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/menu/TreeRow.tsx
+++ b/src/components/menu/TreeRow.tsx
@@ -1,29 +1,7 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-
-export interface MenuItem {
-  id: number;
-  path: string;
-  label: string;
-  groupKey: string;
-  parentId: number | null;
-  position: number;
-  enabled: boolean;
-  access: string;
-  source: string;
-  icon: string | null;
-  touchedAt: number | null;
-  host?: string | null;
-}
-
-export const GROUPS = ['main', 'tools', 'admin', 'hidden'] as const;
-
-export const GROUP_COLORS: Record<string, string> = {
-  main: 'bg-blue-500/10 text-blue-300 border-blue-500/30',
-  tools: 'bg-purple-500/10 text-purple-300 border-purple-500/30',
-  admin: 'bg-amber-500/10 text-amber-300 border-amber-500/30',
-  hidden: 'bg-gray-500/10 text-gray-400 border-gray-500/30',
-};
+import type { MenuItem } from './SortableRow';
+import { GROUP_COLORS } from './SortableRow';
 
 const SOURCE_COLORS: Record<string, string> = {
   route: 'bg-blue-500/10 text-blue-300',
@@ -35,18 +13,23 @@ const SOURCE_COLORS: Record<string, string> = {
 
 interface Props {
   item: MenuItem;
+  depth: number;
+  hasChildren: boolean;
   onPatch: (id: number, patch: Partial<MenuItem>) => void;
+  onEdit: (item: MenuItem) => void;
   onReset: (id: number) => void;
   onDelete: (id: number) => void;
 }
 
-export function SortableRow({ item, onPatch, onReset, onDelete }: Props) {
+export function TreeRow({ item, depth, hasChildren, onPatch, onEdit, onReset, onDelete }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id });
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
+    paddingLeft: depth * 24,
   };
+  const host = item.host ?? null;
   return (
     <div
       ref={setNodeRef}
@@ -57,9 +40,12 @@ export function SortableRow({ item, onPatch, onReset, onDelete }: Props) {
         {...attributes}
         {...listeners}
         className="cursor-grab active:cursor-grabbing text-text-secondary hover:text-accent select-none px-1"
-        title="Drag to reorder"
+        title="Drag to reorder within siblings"
       >
         ⋮⋮
+      </span>
+      <span className="text-xs text-text-secondary w-4 text-center" title={hasChildren ? 'Has children' : ''}>
+        {hasChildren ? '▸' : '·'}
       </span>
       <input
         type="checkbox"
@@ -69,24 +55,19 @@ export function SortableRow({ item, onPatch, onReset, onDelete }: Props) {
         title="Enabled"
       />
       <span className="text-xs text-text-secondary font-mono w-10">#{item.position}</span>
-      <input
-        type="text"
-        defaultValue={item.label}
-        onBlur={(e) => { if (e.target.value !== item.label) onPatch(item.id, { label: e.target.value }); }}
-        className="bg-transparent border-b border-transparent hover:border-border focus:border-accent focus:outline-none px-1 font-medium flex-none w-40"
-      />
+      <span className="font-medium flex-none w-40 truncate">{item.label}</span>
       <code className="text-xs text-text-secondary font-mono flex-1 truncate">{item.path}</code>
+      <span className={`px-2 py-0.5 rounded text-[10px] border ${GROUP_COLORS[item.groupKey] ?? ''}`}>{item.groupKey}</span>
       <span className={`px-2 py-0.5 rounded text-[10px] ${SOURCE_COLORS[item.source] ?? ''}`}>{item.source}</span>
+      {host && (
+        <span className="px-2 py-0.5 rounded text-[10px] bg-indigo-500/10 text-indigo-300 border border-indigo-500/30 font-mono" title="Host filter">
+          {host}
+        </span>
+      )}
       {item.touchedAt && (
         <span className="px-2 py-0.5 rounded text-[10px] bg-amber-500/10 text-amber-300 border border-amber-500/20">edited</span>
       )}
-      <select
-        value={item.groupKey}
-        onChange={(e) => onPatch(item.id, { groupKey: e.target.value })}
-        className="bg-bg-base border border-border rounded px-2 py-1 text-xs"
-      >
-        {GROUPS.map((g) => <option key={g} value={g}>{g}</option>)}
-      </select>
+      <button onClick={() => onEdit(item)} className="text-xs text-text-secondary hover:text-accent" title="Edit">edit</button>
       {item.touchedAt && item.source === 'route' && (
         <button onClick={() => onReset(item.id)} className="text-xs text-text-secondary hover:text-accent" title="Reset">reset</button>
       )}

--- a/src/pages/MenuEditor.tsx
+++ b/src/pages/MenuEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { API_BASE } from '../api/oracle';
 import { cacheBus } from '../lib/cache';
 import {
@@ -17,15 +17,27 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { GistSourceConfig } from '../components/menu/GistSourceConfig';
-import { SortableRow, GROUPS, GROUP_COLORS, type MenuItem } from '../components/menu/SortableRow';
+import type { MenuItem } from '../components/menu/SortableRow';
+import { TreeRow } from '../components/menu/TreeRow';
+import { NodeEditDialog } from '../components/menu/NodeEditDialog';
+
+type SiblingKey = string; // `${parentId ?? 'root'}`
+
+function siblingKey(parentId: number | null): SiblingKey {
+  return parentId == null ? 'root' : String(parentId);
+}
 
 export function MenuEditor() {
   const [items, setItems] = useState<MenuItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [editing, setEditing] = useState<MenuItem | null>(null);
 
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }));
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   async function load() {
     setLoading(true);
@@ -46,73 +58,112 @@ export function MenuEditor() {
 
   function showToast(msg: string) { setToast(msg); setTimeout(() => setToast(null), 2500); }
 
-  async function patchItem(id: number, patch: Partial<MenuItem>) {
+  async function act(label: string, fn: () => Promise<Response>) {
     try {
-      const res = await fetch(`${API_BASE}/menu/items/${id}`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify(patch) });
-      if (!res.ok) throw new Error(`patch ${res.status}`);
+      const res = await fn();
+      if (!res.ok) throw new Error(`${label} ${res.status}`);
       cacheBus.invalidate('menu');
-      showToast('Saved'); await load();
-    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
+      showToast(label); await load();
+    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); await load(); }
   }
-  async function resetItem(id: number) {
-    try {
-      const res = await fetch(`${API_BASE}/menu/reset/${id}`, { method: 'POST' });
-      if (!res.ok) throw new Error(`reset ${res.status}`);
-      cacheBus.invalidate('menu');
-      showToast('Reset'); await load();
-    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
-  }
-  async function deleteItem(id: number) {
+
+  const JSON_H = { 'content-type': 'application/json' };
+  const patchItem = (id: number, patch: Partial<MenuItem>) =>
+    act('Saved', () => fetch(`${API_BASE}/menu/items/${id}`, { method: 'PATCH', headers: JSON_H, body: JSON.stringify(patch) }));
+  const resetItem = (id: number) =>
+    act('Reset', () => fetch(`${API_BASE}/menu/reset/${id}`, { method: 'POST' }));
+  const deleteItem = (id: number) => {
     if (!confirm('Delete this menu item?')) return;
-    try {
-      const res = await fetch(`${API_BASE}/menu/items/${id}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error(`delete ${res.status}`);
-      cacheBus.invalidate('menu');
-      showToast('Deleted'); await load();
-    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
-  }
+    return act('Deleted', () => fetch(`${API_BASE}/menu/items/${id}`, { method: 'DELETE' }));
+  };
   async function addCustom() {
     const path = prompt('Path (e.g. /my-link):'); if (!path) return;
     const label = prompt('Label:', path.replace(/^\//, '').replace(/^./, (c) => c.toUpperCase())); if (!label) return;
-    try {
-      const res = await fetch(`${API_BASE}/menu/items`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ path, label, group: 'main', order: 999, source: 'custom', access: 'public' }) });
-      if (!res.ok) throw new Error(`create ${res.status}`);
-      cacheBus.invalidate('menu');
-      showToast('Created'); await load();
-    } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); }
+    const body = JSON.stringify({ path, label, group: 'main', order: 999, source: 'custom', access: 'public' });
+    await act('Created', () => fetch(`${API_BASE}/menu/items`, { method: 'POST', headers: JSON_H, body }));
   }
 
-  async function handleDragEnd(group: string, e: DragEndEvent) {
+  // Group by parent — one DndContext per sibling group for within-parent reorder.
+  const siblings = useMemo(() => {
+    const map = new Map<SiblingKey, MenuItem[]>();
+    for (const it of items) {
+      const key = siblingKey(it.parentId ?? null);
+      const arr = map.get(key) ?? [];
+      arr.push(it);
+      map.set(key, arr);
+    }
+    for (const arr of map.values()) arr.sort((a, b) => a.position - b.position);
+    return map;
+  }, [items]);
+
+  const hasChildren = useMemo(() => {
+    const set = new Set<number>();
+    for (const it of items) if (it.parentId != null) set.add(it.parentId);
+    return set;
+  }, [items]);
+
+  async function handleDragEnd(parentId: number | null, e: DragEndEvent) {
     const { active, over } = e;
     if (!over || active.id === over.id) return;
-    const groupItems = items.filter((i) => i.groupKey === group).sort((a, b) => a.position - b.position);
-    const oldIdx = groupItems.findIndex((i) => i.id === active.id);
-    const newIdx = groupItems.findIndex((i) => i.id === over.id);
+    const group = siblings.get(siblingKey(parentId)) ?? [];
+    const oldIdx = group.findIndex((i) => i.id === active.id);
+    const newIdx = group.findIndex((i) => i.id === over.id);
     if (oldIdx < 0 || newIdx < 0) return;
-    const reordered = arrayMove(groupItems, oldIdx, newIdx);
-    const payload = reordered.map((i, idx) => ({ id: i.id, parentId: i.parentId, position: (idx + 1) * 10 }));
+    const reordered = arrayMove(group, oldIdx, newIdx);
+    const payload = reordered.map((i, idx) => ({ id: i.id, parentId, position: (idx + 1) * 10 }));
     setItems((prev) => prev.map((i) => {
       const upd = payload.find((p) => p.id === i.id);
       return upd ? { ...i, position: upd.position } : i;
     }));
     try {
-      const res = await fetch(`${API_BASE}/menu/reorder`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ items: payload }) });
+      const res = await fetch(`${API_BASE}/menu/reorder`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ items: payload }),
+      });
       if (!res.ok) throw new Error(`reorder ${res.status}`);
       cacheBus.invalidate('menu');
       showToast('Reordered'); await load();
     } catch (e) { showToast(`Error: ${e instanceof Error ? e.message : e}`); await load(); }
   }
 
-  const grouped: Record<string, MenuItem[]> = { main: [], tools: [], admin: [], hidden: [] };
-  for (const it of items) (grouped[it.groupKey] ?? (grouped[it.groupKey] = [])).push(it);
-  for (const g of GROUPS) grouped[g].sort((a, b) => a.position - b.position);
+  function renderSiblings(parentId: number | null, depth: number): React.ReactNode {
+    const group = siblings.get(siblingKey(parentId)) ?? [];
+    if (group.length === 0 && parentId == null) {
+      return <div className="text-sm text-text-secondary italic px-3 py-2">(empty)</div>;
+    }
+    return (
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => handleDragEnd(parentId, e)}>
+        <SortableContext items={group.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+          <div className="space-y-1">
+            {group.map((it) => (
+              <div key={it.id}>
+                <TreeRow
+                  item={it}
+                  depth={depth}
+                  hasChildren={hasChildren.has(it.id)}
+                  onPatch={patchItem}
+                  onEdit={setEditing}
+                  onReset={resetItem}
+                  onDelete={deleteItem}
+                />
+                {hasChildren.has(it.id) && renderSiblings(it.id, depth + 1)}
+              </div>
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    );
+  }
 
   return (
     <div className="max-w-[1200px] mx-auto px-6 py-8">
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold">Menu Editor</h1>
-          <p className="text-sm text-text-secondary mt-1">Drag ⋮⋮ to reorder. Routes seed defaults; edits persist. {items.length} items.</p>
+          <p className="text-sm text-text-secondary mt-1">
+            Tree view — drag ⋮⋮ to reorder within siblings. Click <span className="text-accent">edit</span> to change parent, host, or group. {items.length} items.
+          </p>
         </div>
         <button onClick={addCustom} className="px-4 py-2 rounded-lg bg-accent/20 hover:bg-accent/30 text-accent border border-accent/40 text-sm font-medium">+ Add Custom Item</button>
       </div>
@@ -122,24 +173,20 @@ export function MenuEditor() {
       {loading && <div className="text-text-secondary">Loading…</div>}
       {error && <div className="text-red-400">Error: {error}</div>}
 
-      {!loading && !error && GROUPS.map((g) => (
-        <section key={g} className="mb-8">
-          <h2 className="text-lg font-semibold mb-3 capitalize flex items-center gap-2">
-            <span className={`px-2 py-0.5 rounded text-xs border ${GROUP_COLORS[g]}`}>{g}</span>
-            <span className="text-text-secondary text-sm">({grouped[g]?.length ?? 0})</span>
-          </h2>
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => handleDragEnd(g, e)}>
-            <SortableContext items={(grouped[g] ?? []).map((i) => i.id)} strategy={verticalListSortingStrategy}>
-              <div className="space-y-1">
-                {(grouped[g] ?? []).map((it) => (
-                  <SortableRow key={it.id} item={it} onPatch={patchItem} onReset={resetItem} onDelete={deleteItem} />
-                ))}
-                {(grouped[g]?.length ?? 0) === 0 && <div className="text-sm text-text-secondary italic px-3 py-2">(empty)</div>}
-              </div>
-            </SortableContext>
-          </DndContext>
+      {!loading && !error && (
+        <section className="mb-8">
+          {renderSiblings(null, 0)}
         </section>
-      ))}
+      )}
+
+      {editing && (
+        <NodeEditDialog
+          item={editing}
+          allItems={items}
+          onClose={() => setEditing(null)}
+          onSave={(patch) => patchItem(editing.id, patch)}
+        />
+      )}
 
       {toast && <div className="fixed bottom-6 right-6 px-4 py-2 rounded-lg bg-bg-elevated border border-accent/40 shadow-lg text-sm">{toast}</div>}
     </div>


### PR DESCRIPTION
## Summary

- Switches `/menu` editor from flat grouped view to a recursive tree view.
- Per-sibling-group DnD reorder via `dnd-kit` (existing dep).
- Edit dialog adds **Parent** reassignment (dropdown, null = root) and **Host** filter (glob, blank = all hosts).
- Visual indent: 24px per depth; `▸` marker for nodes with children.

## Re-parent UX

Drop-into-other-subtree DnD was descoped to keep the PR focused. Parent changes flow through the edit dialog (covers all re-parent cases, including → root). Follow-up issue will add drop-into DnD.

## Host filter

`host` field on `MenuItem` accepts `string | null`. Blank input = `null` (all hosts). Rendered as an indigo pill on the row when set.

## Files

- `src/pages/MenuEditor.tsx` — rewritten to tree (≤200 lines)
- `src/components/menu/TreeRow.tsx` — new sortable row with depth indent + host badge
- `src/components/menu/NodeEditDialog.tsx` — new modal (label/route/group/parent/host)
- `src/components/menu/SortableRow.tsx` — added `host?: string | null` to `MenuItem`

## Test plan

- [x] `bun tsc --noEmit` — 0 errors
- [x] `bun run build` — success
- [x] `bun test` — 55 pass (1 pre-existing Playwright e2e failure unrelated: `@playwright/test` not installed)
- [ ] Manual: load `/menu`, reorder siblings via drag, reassign parent via Edit, set host, verify PATCH payload
- [ ] Manual: drop-to-root via Parent → (root)

Closes Soul-Brews-Studio/arra-oracle-v3#946