### PR TITLE
fix(ui): show unindexed engines as Offline, reduce stats cache TTL

### DIFF
--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -218,7 +218,7 @@ export async function getMap(): Promise<{ documents: MapDocument[]; total: numbe
 export async function getMap3d(model?: string): Promise<{ documents: MapDocument[]; total: number; pca_info?: any }> {
   const params = model ? `?model=${encodeURIComponent(model)}` : '';
   const key = `map3d:${model ?? 'default'}`;
-  return cached(key, ONE_DAY, async () => {
+  return cached(key, TEN_MIN, async () => {
     const res = await fetch(`${API_BASE}/map3d${params}`);
     return res.json();
   }, { tag: 'map3d', store: 'idb' });

--- a/src/api/oracle.ts
+++ b/src/api/oracle.ts
@@ -101,7 +101,7 @@ export async function list(type: string = 'all', limit: number = 20, offset: num
 
 // Get stats
 export async function getStats(): Promise<Stats> {
-  return cached('stats', ONE_HOUR, async () => {
+  return cached('stats', TEN_MIN, async () => {
     const res = await fetch(`${API_BASE}/stats`);
     if (!res.ok) {
       throw new Error(`Server error: ${res.status}`);

--- a/src/components/planets/EngineList.tsx
+++ b/src/components/planets/EngineList.tsx
@@ -27,11 +27,11 @@ export function EngineList({ engines, model, onSetModel }: Props) {
           <button
             key={v.key}
             onClick={() => v.enabled && onSetModel(v.key)}
-            disabled={!v.enabled}
+            disabled={!v.enabled || v.count === 0}
             className={`flex flex-col gap-0.5 p-2 rounded-lg border text-left transition-all duration-150 ${
               active
                 ? 'border-accent/40 bg-accent/5'
-                : v.enabled
+                : v.enabled && v.count > 0
                 ? 'border-border bg-white/[0.02] hover:border-border-hover cursor-pointer'
                 : 'border-border-subtle opacity-50 cursor-not-allowed'
             }`}
@@ -49,7 +49,7 @@ export function EngineList({ engines, model, onSetModel }: Props) {
                     : 'bg-red-500/20 text-red-400'
                 }`}
               >
-                {active ? 'Active' : v.enabled ? 'Switch' : 'Offline'}
+                {active ? 'Active' : v.enabled && v.count > 0 ? 'Switch' : 'Offline'}
               </span>
             </div>
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- **EngineList**: engines with `count=0` now show `Offline`/disabled instead of `Switch` — prevents misleading UI for nomic/qwen3 collections that have no indexed vectors
- **oracle.ts**: stats cache TTL reduced from 1h → 10min so `vector.count` reflects reality promptly after a reindex instead of showing stale `0`

## Root cause

nara QA (anti-false-pass) found:
1. `EngineList` showed unindexed models (nomic/qwen3) as `Switch` even when `count=0` — clicking them would return 0 results
2. `Overview` showed `0 Embeddings` because `oracle_cache/v1:stats` localStorage had a stale 1h-cached entry from before the bge-m3 reindex

## Test plan

- [x] EngineList: nomic + qwen3 show `Offline` (disabled) when `count=0`; bge-m3 shows `Active`
- [x] Overview Embeddings stat: shows `3,077` after fresh load (version-invalidation clears stale localStorage cache automatically on bundle update)
- [x] Stale-cache inject test: planted bad entry (v=old, count=0) → reload new bundle → auto-invalidated, counter shows correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)